### PR TITLE
test: remove unsupported Node version checks from fetch tests

### DIFF
--- a/test/fetch/cookies.js
+++ b/test/fetch/cookies.js
@@ -8,10 +8,6 @@ const { Client, fetch, Headers } = require('../..')
 const pem = require('@metcoder95/https-pem')
 const { createSecureServer } = require('node:http2')
 
-const isMacOSNode20CI = process.platform === 'darwin' &&
-  Number(process.versions.node.split('.')[0]) === 20 &&
-  process.env.CI
-
 describe('cookies', () => {
   let server
 
@@ -32,9 +28,7 @@ describe('cookies', () => {
     return once(server, 'close')
   })
 
-  test('Can receive set-cookie headers from a server using fetch - issue #1262', {
-    skip: isMacOSNode20CI
-  }, async (t) => {
+  test('Can receive set-cookie headers from a server using fetch - issue #1262', async (t) => {
     const query = qsStringify({
       'set-cookie': 'name=value; Domain=example.com'
     })
@@ -65,9 +59,7 @@ describe('cookies', () => {
     }
   })
 
-  test('Cookie header is delimited with a semicolon rather than a comma - issue #1905', {
-    skip: isMacOSNode20CI
-  }, async (t) => {
+  test('Cookie header is delimited with a semicolon rather than a comma - issue #1905', async (t) => {
     const response = await fetch(`http://localhost:${server.address().port}`, {
       headers: [
         ['cookie', 'FOO=lorem-ipsum-dolor-sit-amet'],

--- a/test/fetch/issue-4105.js
+++ b/test/fetch/issue-4105.js
@@ -5,10 +5,9 @@ const { createServer } = require('node:http')
 const { test } = require('node:test')
 const { fetch } = require('../..')
 const { PerformanceObserver } = require('node:perf_hooks')
-const isAtLeastv22 = process.versions.node.split('.').map(Number)[0] >= 22
 
 // https://github.com/nodejs/undici/issues/4105
-test('markResourceTiming responseStatus is set', { skip: !isAtLeastv22 }, async (t) => {
+test('markResourceTiming responseStatus is set', async (t) => {
   t.plan(1)
 
   const promise = Promise.withResolvers()


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

N/A

## Rationale

Some fetch tests still contained checks for unsupported Node versions or CI-specific environments and were being skipped conditionally. Those checks are no longer needed, so the tests should run unconditionally.

## Changes

- Removed the `isAtLeastv22` check from `test/fetch/issue-4105.js`
- Removed the `isMacOSNode20CI` check from `test/fetch/cookies.js`
- Removed the related `skip` conditions so the affected fetch tests always run

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
