### PR TITLE
chore: avoid quadratic copies for fragmented headers in client-h1

### DIFF
--- a/benchmarks/client-h1-fragmented-headers.mjs
+++ b/benchmarks/client-h1-fragmented-headers.mjs
@@ -1,0 +1,254 @@
+import { bench, group, run } from 'mitata'
+import { bufferToLowerCasedHeaderName } from '../lib/core/util.js'
+
+const valueLength = parseInt(process.env.VALUE_LENGTH, 10) || 16 * 1024
+const fieldFragmentSize = parseInt(process.env.FIELD_FRAGMENT_SIZE, 10) || 1
+
+let sink = 0
+
+class HeaderAccumulatorBase {
+  constructor () {
+    this.reset()
+  }
+
+  reset () {
+    this.headers = []
+    this.headersSize = 0
+    this.keepAlive = ''
+    this.connection = ''
+    this.contentLength = ''
+  }
+
+  trackHeader (length) {
+    this.headersSize += length
+  }
+
+  updateSpecialHeaders (key, buf) {
+    if (key.length === 10) {
+      const headerName = bufferToLowerCasedHeaderName(key)
+      if (headerName === 'keep-alive') {
+        this.keepAlive += buf.toString()
+      } else if (headerName === 'connection') {
+        this.connection += buf.toString()
+      }
+    } else if (key.length === 14 && bufferToLowerCasedHeaderName(key) === 'content-length') {
+      this.contentLength += buf.toString()
+    }
+  }
+}
+
+class EagerConcatAccumulator extends HeaderAccumulatorBase {
+  onHeaderField (buf) {
+    const len = this.headers.length
+
+    if ((len & 1) === 0) {
+      this.headers.push(buf)
+    } else {
+      this.headers[len - 1] = Buffer.concat([this.headers[len - 1], buf])
+    }
+
+    this.trackHeader(buf.length)
+  }
+
+  onHeaderValue (buf) {
+    let len = this.headers.length
+
+    if ((len & 1) === 1) {
+      this.headers.push(buf)
+      len += 1
+    } else {
+      this.headers[len - 1] = Buffer.concat([this.headers[len - 1], buf])
+    }
+
+    this.updateSpecialHeaders(this.headers[len - 2], buf)
+    this.trackHeader(buf.length)
+  }
+
+  finish () {
+    const len = this.headers.length
+    return this.headersSize +
+      this.keepAlive.length +
+      this.connection.length +
+      this.contentLength.length +
+      this.headers[len - 2].length +
+      this.headers[len - 1].length
+  }
+}
+
+class DeferredFlattenAccumulator extends HeaderAccumulatorBase {
+  reset () {
+    super.reset()
+    this.currentHeaderIndex = -1
+    this.headerFragments = null
+    this.headerFragmentsSize = 0
+  }
+
+  onHeaderField (buf) {
+    const len = this.headers.length
+
+    if ((len & 1) === 0) {
+      if (len !== 0) {
+        this.flushHeader()
+      }
+      this.startHeader(buf)
+    } else {
+      this.appendHeader(buf)
+    }
+
+    this.trackHeader(buf.length)
+  }
+
+  onHeaderValue (buf) {
+    const len = this.headers.length
+    let key
+
+    if ((len & 1) === 1) {
+      key = this.flushHeader()
+      this.startHeader(buf)
+    } else {
+      this.appendHeader(buf)
+      key = this.headers[len - 2]
+    }
+
+    this.updateSpecialHeaders(key, buf)
+    this.trackHeader(buf.length)
+  }
+
+  startHeader (buf) {
+    this.headers.push(buf)
+    this.currentHeaderIndex = this.headers.length - 1
+    this.headerFragments = null
+    this.headerFragmentsSize = 0
+  }
+
+  appendHeader (buf) {
+    if (this.headerFragments === null) {
+      const current = this.headers[this.currentHeaderIndex]
+      this.headerFragments = [current, buf]
+      this.headerFragmentsSize = current.length + buf.length
+    } else {
+      this.headerFragments.push(buf)
+      this.headerFragmentsSize += buf.length
+    }
+  }
+
+  flushHeader () {
+    if (this.currentHeaderIndex === -1) {
+      return null
+    }
+
+    if (this.headerFragments !== null) {
+      const buf = Buffer.allocUnsafe(this.headerFragmentsSize)
+      let offset = 0
+
+      for (let i = 0; i < this.headerFragments.length; ++i) {
+        const fragment = this.headerFragments[i]
+        fragment.copy(buf, offset)
+        offset += fragment.length
+      }
+
+      this.headers[this.currentHeaderIndex] = buf
+      this.headerFragments = null
+      this.headerFragmentsSize = 0
+    }
+
+    return this.headers[this.currentHeaderIndex]
+  }
+
+  finish () {
+    this.flushHeader()
+
+    const len = this.headers.length
+    return this.headersSize +
+      this.keepAlive.length +
+      this.connection.length +
+      this.contentLength.length +
+      this.headers[len - 2].length +
+      this.headers[len - 1].length
+  }
+}
+
+function fragmentBuffer (value, fragmentSize) {
+  const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value)
+  const fragments = []
+
+  for (let i = 0; i < buffer.length; i += fragmentSize) {
+    fragments.push(buffer.subarray(i, i + fragmentSize))
+  }
+
+  return fragments
+}
+
+function buildScenario ({ fragmentedField, valueFragmentSize }) {
+  const customField = fragmentBuffer('x-benchmark-fragmented-header', fragmentedField ? fieldFragmentSize : 64)
+  const customValue = fragmentBuffer('a'.repeat(valueLength), valueFragmentSize)
+
+  return [
+    {
+      field: fragmentBuffer('connection', fragmentedField ? fieldFragmentSize : 64),
+      value: fragmentBuffer('keep-alive', valueFragmentSize)
+    },
+    {
+      field: customField,
+      value: customValue
+    },
+    {
+      field: fragmentBuffer('content-length', fragmentedField ? fieldFragmentSize : 64),
+      value: fragmentBuffer(String(valueLength), valueFragmentSize)
+    }
+  ]
+}
+
+function runScenario (accumulator, scenario) {
+  accumulator.reset()
+
+  for (let i = 0; i < scenario.length; ++i) {
+    const header = scenario[i]
+
+    for (let j = 0; j < header.field.length; ++j) {
+      accumulator.onHeaderField(header.field[j])
+    }
+
+    for (let j = 0; j < header.value.length; ++j) {
+      accumulator.onHeaderValue(header.value[j])
+    }
+  }
+
+  sink ^= accumulator.finish()
+}
+
+const scenarios = {
+  'field fragmented, value fragmented byte-by-byte': buildScenario({
+    fragmentedField: true,
+    valueFragmentSize: 1
+  }),
+  'field fragmented, value fragmented in 16-byte chunks': buildScenario({
+    fragmentedField: true,
+    valueFragmentSize: 16
+  }),
+  'field contiguous, value fragmented byte-by-byte': buildScenario({
+    fragmentedField: false,
+    valueFragmentSize: 1
+  })
+}
+
+for (const [name, scenario] of Object.entries(scenarios)) {
+  const eager = new EagerConcatAccumulator()
+  const deferred = new DeferredFlattenAccumulator()
+
+  group(`${name} (value length ${valueLength})`, () => {
+    bench('legacy eager Buffer.concat', () => {
+      runScenario(eager, scenario)
+    })
+
+    bench('deferred flatten', () => {
+      runScenario(deferred, scenario)
+    })
+  })
+}
+
+await run()
+
+if (sink === Number.MIN_SAFE_INTEGER) {
+  console.log('unreachable', sink)
+}

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -4,6 +4,7 @@
     "bench": "PORT=3042 concurrently -k -s first npm:bench:server npm:bench:run",
     "bench:h2": "PORT=3052 concurrently -k -s first npm:bench:server:h2 npm:bench:run:h2",
     "bench-post": "PORT=3042 concurrently -k -s first npm:bench:server npm:bench-post:run",
+    "bench:client-h1:headers": "node ./client-h1-fragmented-headers.mjs",
     "bench:server": "node ./server.js",
     "bench:server:h2": "node ./server-http2.js",
     "prebench:run": "node ./wait.js",

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -222,6 +222,9 @@ class Parser {
     this.statusText = ''
     this.upgrade = false
     this.headers = []
+    this.currentHeaderIndex = -1
+    this.headerFragments = null
+    this.headerFragmentsSize = 0
     this.headersSize = 0
     this.headersMaxSize = client[kMaxHeadersSize]
     this.shouldKeepAlive = false
@@ -417,9 +420,12 @@ class Parser {
     const len = this.headers.length
 
     if ((len & 1) === 0) {
-      this.headers.push(buf)
+      if (len !== 0) {
+        this.flushHeader()
+      }
+      this.startHeader(buf)
     } else {
-      this.headers[len - 1] = Buffer.concat([this.headers[len - 1], buf])
+      this.appendHeader(buf)
     }
 
     this.trackHeader(buf.length)
@@ -432,16 +438,17 @@ class Parser {
    * @returns {number}
    */
   onHeaderValue (buf) {
-    let len = this.headers.length
+    const len = this.headers.length
+    let key
 
     if ((len & 1) === 1) {
-      this.headers.push(buf)
-      len += 1
+      key = this.flushHeader()
+      this.startHeader(buf)
     } else {
-      this.headers[len - 1] = Buffer.concat([this.headers[len - 1], buf])
+      this.appendHeader(buf)
+      key = this.headers[len - 2]
     }
 
-    const key = this.headers[len - 2]
     if (key.length === 10) {
       const headerName = util.bufferToLowerCasedHeaderName(key)
       if (headerName === 'keep-alive') {
@@ -469,6 +476,64 @@ class Parser {
   }
 
   /**
+   * @param {Buffer} buf
+   */
+  startHeader (buf) {
+    this.headers.push(buf)
+    this.currentHeaderIndex = this.headers.length - 1
+    this.headerFragments = null
+    this.headerFragmentsSize = 0
+  }
+
+  /**
+   * @param {Buffer} buf
+   */
+  appendHeader (buf) {
+    if (this.headerFragments === null) {
+      const current = this.headers[this.currentHeaderIndex]
+      this.headerFragments = [current, buf]
+      this.headerFragmentsSize = current.length + buf.length
+    } else {
+      this.headerFragments.push(buf)
+      this.headerFragmentsSize += buf.length
+    }
+  }
+
+  /**
+   * @returns {Buffer | null}
+   */
+  flushHeader () {
+    if (this.currentHeaderIndex === -1) {
+      return null
+    }
+
+    if (this.headerFragments !== null) {
+      const buf = Buffer.allocUnsafe(this.headerFragmentsSize)
+      let offset = 0
+
+      for (let i = 0; i < this.headerFragments.length; ++i) {
+        const fragment = this.headerFragments[i]
+        fragment.copy(buf, offset)
+        offset += fragment.length
+      }
+
+      this.headers[this.currentHeaderIndex] = buf
+      this.headerFragments = null
+      this.headerFragmentsSize = 0
+    }
+
+    return this.headers[this.currentHeaderIndex]
+  }
+
+  resetHeaders () {
+    this.headers = []
+    this.currentHeaderIndex = -1
+    this.headerFragments = null
+    this.headerFragmentsSize = 0
+    this.headersSize = 0
+  }
+
+  /**
    * @param {Buffer} head
    */
   onUpgrade (head) {
@@ -478,6 +543,8 @@ class Parser {
     assert(client[kSocket] === socket)
     assert(!socket.destroyed)
     assert(!this.paused)
+
+    this.flushHeader()
     assert((headers.length & 1) === 0)
 
     const request = client[kQueue][client[kRunningIdx]]
@@ -488,8 +555,7 @@ class Parser {
     this.statusText = ''
     this.shouldKeepAlive = false
 
-    this.headers = []
-    this.headersSize = 0
+    this.resetHeaders()
 
     socket.unshift(head)
 
@@ -580,9 +646,9 @@ class Parser {
       return 2
     }
 
+    this.flushHeader()
     assert((this.headers.length & 1) === 0)
-    this.headers = []
-    this.headersSize = 0
+    this.resetHeaders()
 
     if (this.shouldKeepAlive && client[kPipelining]) {
       const keepAliveTimeout = this.keepAlive ? util.parseKeepAliveTimeout(this.keepAlive) : null
@@ -679,6 +745,8 @@ class Parser {
     }
 
     assert(statusCode >= 100)
+
+    this.flushHeader()
     assert((this.headers.length & 1) === 0)
 
     const request = client[kQueue][client[kRunningIdx]]
@@ -691,8 +759,7 @@ class Parser {
     this.keepAlive = ''
     this.connection = ''
 
-    this.headers = []
-    this.headersSize = 0
+    this.resetHeaders()
 
     if (statusCode < 200) {
       return 0

--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -5,6 +5,19 @@ const { test, after } = require('node:test')
 const net = require('node:net')
 const { Client, errors } = require('..')
 
+function writeChunks (socket, chunks, delay = 1) {
+  socket.write(chunks[0])
+
+  let index = 1
+  const timer = setInterval(() => {
+    socket.write(chunks[index++])
+
+    if (index === chunks.length) {
+      clearInterval(timer)
+    }
+  }, delay)
+}
+
 test('https://github.com/mcollina/undici/issues/268', async (t) => {
   t = tspl(t, { plan: 2 })
 
@@ -122,6 +135,71 @@ test('split header value', async (t) => {
       path: '/'
     }, (err, data) => {
       t.ifError(err)
+      t.equal(data.headers.asd, 'asd,asd')
+      data.body.destroy().on('error', () => {})
+    })
+  })
+
+  await t.completed
+})
+
+test('repeatedly split header field and value', async (t) => {
+  t = tspl(t, { plan: 3 })
+
+  const server = net.createServer(socket => {
+    writeChunks(socket, [
+      'HTTP/1.1 200 OK\r\n',
+      'C',
+      'o',
+      'n',
+      'n',
+      'e',
+      'c',
+      't',
+      'i',
+      'o',
+      'n',
+      ':',
+      ' ',
+      'k',
+      'e',
+      'e',
+      'p',
+      '-',
+      'a',
+      'l',
+      'i',
+      'v',
+      'e',
+      '\r\n',
+      'A',
+      'S',
+      'D',
+      ': ',
+      'a',
+      's',
+      'd',
+      ',',
+      'a',
+      's',
+      'd',
+      '\r\n',
+      'Content-Length: 0\r\n',
+      '\r\n'
+    ])
+  })
+  after(() => server.close())
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(() => client.destroy())
+
+    client.request({
+      method: 'GET',
+      path: '/'
+    }, (err, data) => {
+      t.ifError(err)
+      t.equal(data.headers.connection, 'keep-alive')
       t.equal(data.headers.asd, 'asd,asd')
       data.body.destroy().on('error', () => {})
     })


### PR DESCRIPTION
Benchmark showed existing code is performant