### PR TITLE
perf: reduce EventSourceStream buffer churn

### DIFF
--- a/benchmarks/eventsource/eventsource-stream.mjs
+++ b/benchmarks/eventsource/eventsource-stream.mjs
@@ -1,0 +1,437 @@
+import assert from 'node:assert/strict'
+import eventsourceStreamModule from '../../lib/web/eventsource/eventsource-stream.js'
+import { bench, group, run } from 'mitata'
+
+const { EventSourceStream } = eventsourceStreamModule
+
+const noop = () => {}
+
+const BOM_BYTES = [0xEF, 0xBB, 0xBF]
+const LF = 0x0A
+const CR = 0x0D
+const COLON = 0x3A
+const SPACE = 0x20
+
+function isValidLastEventId (value) {
+  return value.indexOf('\u0000') === -1
+}
+
+function isASCIINumber (value) {
+  if (value.length === 0) return false
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) < 0x30 || value.charCodeAt(i) > 0x39) return false
+  }
+  return true
+}
+
+class LegacyEventSourceStream {
+  checkBOM = true
+
+  crlfCheck = false
+
+  eventEndCheck = false
+
+  buffer = null
+
+  pos = 0
+
+  event = {
+    data: undefined,
+    event: undefined,
+    id: undefined,
+    retry: undefined
+  }
+
+  constructor (options = {}) {
+    this.state = options.eventSourceSettings || {}
+  }
+
+  _transform (chunk, _encoding, callback) {
+    if (chunk.length === 0) {
+      callback()
+      return
+    }
+
+    if (this.buffer) {
+      this.buffer = Buffer.concat([this.buffer, chunk])
+    } else {
+      this.buffer = chunk
+    }
+
+    if (this.checkBOM) {
+      switch (this.buffer.length) {
+        case 1:
+          if (this.buffer[0] === BOM_BYTES[0]) {
+            callback()
+            return
+          }
+
+          this.checkBOM = false
+          callback()
+          return
+        case 2:
+          if (
+            this.buffer[0] === BOM_BYTES[0] &&
+            this.buffer[1] === BOM_BYTES[1]
+          ) {
+            callback()
+            return
+          }
+
+          this.checkBOM = false
+          break
+        case 3:
+          if (
+            this.buffer[0] === BOM_BYTES[0] &&
+            this.buffer[1] === BOM_BYTES[1] &&
+            this.buffer[2] === BOM_BYTES[2]
+          ) {
+            this.buffer = Buffer.alloc(0)
+            this.checkBOM = false
+            callback()
+            return
+          }
+
+          this.checkBOM = false
+          break
+        default:
+          if (
+            this.buffer[0] === BOM_BYTES[0] &&
+            this.buffer[1] === BOM_BYTES[1] &&
+            this.buffer[2] === BOM_BYTES[2]
+          ) {
+            this.buffer = this.buffer.subarray(3)
+          }
+
+          this.checkBOM = false
+          break
+      }
+    }
+
+    while (this.pos < this.buffer.length) {
+      if (this.eventEndCheck) {
+        if (this.crlfCheck) {
+          if (this.buffer[this.pos] === LF) {
+            this.buffer = this.buffer.subarray(this.pos + 1)
+            this.pos = 0
+            this.crlfCheck = false
+            continue
+          }
+
+          this.crlfCheck = false
+        }
+
+        if (this.buffer[this.pos] === LF || this.buffer[this.pos] === CR) {
+          if (this.buffer[this.pos] === CR) {
+            this.crlfCheck = true
+          }
+
+          this.buffer = this.buffer.subarray(this.pos + 1)
+          this.pos = 0
+          if (
+            this.event.data !== undefined ||
+            this.event.event ||
+            this.event.id !== undefined ||
+            this.event.retry
+          ) {
+            this.processEvent(this.event)
+          }
+          this.clearEvent()
+          continue
+        }
+
+        this.eventEndCheck = false
+        continue
+      }
+
+      if (this.buffer[this.pos] === LF || this.buffer[this.pos] === CR) {
+        if (this.buffer[this.pos] === CR) {
+          this.crlfCheck = true
+        }
+
+        this.parseLine(this.buffer.subarray(0, this.pos), this.event)
+        this.buffer = this.buffer.subarray(this.pos + 1)
+        this.pos = 0
+        this.eventEndCheck = true
+        continue
+      }
+
+      this.pos++
+    }
+
+    callback()
+  }
+
+  parseLine (line, event) {
+    if (line.length === 0) {
+      return
+    }
+
+    const colonPosition = line.indexOf(COLON)
+    if (colonPosition === 0) {
+      return
+    }
+
+    let field = ''
+    let value = ''
+
+    if (colonPosition !== -1) {
+      field = line.subarray(0, colonPosition).toString('utf8')
+
+      let valueStart = colonPosition + 1
+      if (line[valueStart] === SPACE) {
+        ++valueStart
+      }
+
+      value = line.subarray(valueStart).toString('utf8')
+    } else {
+      field = line.toString('utf8')
+      value = ''
+    }
+
+    switch (field) {
+      case 'data':
+        if (event[field] === undefined) {
+          event[field] = value
+        } else {
+          event[field] += `\n${value}`
+        }
+        break
+      case 'retry':
+        if (isASCIINumber(value)) {
+          event[field] = value
+        }
+        break
+      case 'id':
+        if (isValidLastEventId(value)) {
+          event[field] = value
+        }
+        break
+      case 'event':
+        if (value.length > 0) {
+          event[field] = value
+        }
+        break
+    }
+  }
+
+  processEvent (event) {
+    if (event.retry && isASCIINumber(event.retry)) {
+      this.state.reconnectionTime = parseInt(event.retry, 10)
+    }
+
+    if (event.id !== undefined && isValidLastEventId(event.id)) {
+      this.state.lastEventId = event.id
+    }
+  }
+
+  clearEvent () {
+    this.event = {
+      data: undefined,
+      event: undefined,
+      id: undefined,
+      retry: undefined
+    }
+  }
+}
+
+function buildPayload ({ eventCount, includeBOM = false, unicode = false, eol = '\n' }) {
+  let payload = includeBOM ? '\uFEFF' : ''
+
+  for (let i = 0; i < eventCount; i++) {
+    const primaryData = unicode
+      ? `Grüße 😀 event ${i}`
+      : `plain event ${i}`
+
+    payload += `: keepalive ${i}${eol}`
+    payload += `id: ${i}${eol}`
+    payload += `event: update${eol}`
+    payload += `retry: 1500${eol}`
+    payload += `data: ${primaryData}${eol}`
+    payload += `data: second line ${i}${eol}${eol}`
+  }
+
+  return Buffer.from(payload, 'utf8')
+}
+
+function fixedChunks (buffer, size) {
+  const chunks = []
+
+  for (let i = 0; i < buffer.length; i += size) {
+    chunks.push(buffer.subarray(i, i + size))
+  }
+
+  return chunks
+}
+
+function patternedChunks (buffer, pattern) {
+  const chunks = []
+
+  for (let i = 0, offset = 0; offset < buffer.length; i++) {
+    const size = pattern[i % pattern.length]
+    chunks.push(buffer.subarray(offset, offset + size))
+    offset += size
+  }
+
+  return chunks
+}
+
+function runScenario (StreamCtor, chunks) {
+  const stream = new StreamCtor({
+    eventSourceSettings: {
+      origin: 'https://example.com',
+      reconnectionTime: 1000
+    }
+  })
+
+  let checksum = 0
+
+  stream.processEvent = function (event) {
+    if (event.retry && isASCIINumber(event.retry)) {
+      this.state.reconnectionTime = parseInt(event.retry, 10)
+    }
+
+    if (event.id !== undefined && isValidLastEventId(event.id)) {
+      this.state.lastEventId = event.id
+    }
+
+    if (event.data !== undefined) {
+      checksum += event.data.length
+      checksum += event.event ? event.event.length : 0
+      checksum += this.state.lastEventId ? this.state.lastEventId.length : 0
+      checksum += this.state.reconnectionTime || 0
+    }
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    stream._transform(chunks[i], 'buffer', noop)
+  }
+
+  return checksum
+}
+
+function buildParseLineInputs ({ recordCount, unicode = false }) {
+  const inputs = []
+
+  for (let i = 0; i < recordCount; i++) {
+    const value = unicode
+      ? `Grüße 😀 line ${i}`
+      : `plain line ${i}`
+
+    inputs.push(`id: ${i}`)
+    inputs.push('event: update')
+    inputs.push('retry: 1500')
+    inputs.push(`data: ${value}`)
+    inputs.push(`data: second ${i}`)
+  }
+
+  return inputs
+}
+
+function runCurrentParseLineScenario (inputs) {
+  const stream = new EventSourceStream()
+  let checksum = 0
+
+  for (let i = 0; i < inputs.length; i += 5) {
+    const event = {}
+
+    stream.parseLine(inputs[i], event)
+    stream.parseLine(inputs[i + 1], event)
+    stream.parseLine(inputs[i + 2], event)
+    stream.parseLine(inputs[i + 3], event)
+    stream.parseLine(inputs[i + 4], event)
+
+    checksum += event.data.length
+    checksum += event.event.length
+    checksum += event.id.length
+    checksum += event.retry.length
+  }
+
+  return checksum
+}
+
+function runLegacyParseLineScenario (inputs) {
+  const stream = new LegacyEventSourceStream()
+  let checksum = 0
+
+  for (let i = 0; i < inputs.length; i += 5) {
+    const event = {}
+
+    stream.parseLine(Buffer.from(inputs[i]), event)
+    stream.parseLine(Buffer.from(inputs[i + 1]), event)
+    stream.parseLine(Buffer.from(inputs[i + 2]), event)
+    stream.parseLine(Buffer.from(inputs[i + 3]), event)
+    stream.parseLine(Buffer.from(inputs[i + 4]), event)
+
+    checksum += event.data.length
+    checksum += event.event.length
+    checksum += event.id.length
+    checksum += event.retry.length
+  }
+
+  return checksum
+}
+
+const scenarios = {
+  'ascii, 1-byte chunks': fixedChunks(buildPayload({ eventCount: 250 }), 1),
+  'ascii, 32-byte chunks': fixedChunks(buildPayload({ eventCount: 250 }), 32),
+  'utf8 + bom, mixed chunks': patternedChunks(
+    buildPayload({
+      eventCount: 250,
+      includeBOM: true,
+      unicode: true
+    }),
+    [1, 2, 3, 5, 8, 13, 21]
+  )
+}
+
+const parseLineScenarios = {
+  'parseLine, ascii fields': buildParseLineInputs({ recordCount: 1000 }),
+  'parseLine, utf8 fields': buildParseLineInputs({ recordCount: 1000, unicode: true })
+}
+
+for (const [name, chunks] of Object.entries(scenarios)) {
+  const legacyChecksum = runScenario(LegacyEventSourceStream, chunks)
+  const currentChecksum = runScenario(EventSourceStream, chunks)
+
+  assert.equal(currentChecksum, legacyChecksum, `${name} should preserve behavior`)
+}
+
+for (const [name, inputs] of Object.entries(parseLineScenarios)) {
+  const legacyChecksum = runLegacyParseLineScenario(inputs)
+  const currentChecksum = runCurrentParseLineScenario(inputs)
+
+  assert.equal(currentChecksum, legacyChecksum, `${name} should preserve behavior`)
+}
+
+let blackhole = 0
+
+for (const [name, chunks] of Object.entries(scenarios)) {
+  group(name, () => {
+    bench('legacy buffer parser', () => {
+      blackhole ^= runScenario(LegacyEventSourceStream, chunks)
+    })
+
+    bench('current decoder parser', () => {
+      blackhole ^= runScenario(EventSourceStream, chunks)
+    })
+  })
+}
+
+for (const [name, inputs] of Object.entries(parseLineScenarios)) {
+  group(name, () => {
+    bench('legacy parseLine', () => {
+      blackhole ^= runLegacyParseLineScenario(inputs)
+    })
+
+    bench('current parseLine', () => {
+      blackhole ^= runCurrentParseLineScenario(inputs)
+    })
+  })
+}
+
+await run()
+
+if (blackhole === Number.MIN_SAFE_INTEGER) {
+  console.log(blackhole)
+}

--- a/lib/web/eventsource/eventsource-stream.js
+++ b/lib/web/eventsource/eventsource-stream.js
@@ -1,27 +1,28 @@
 'use strict'
 const { Transform } = require('node:stream')
+const { StringDecoder } = require('node:string_decoder')
 const { isASCIINumber, isValidLastEventId } = require('./util')
 
 /**
- * @type {number[]} BOM
+ * @type {'\uFEFF'} BOM
  */
-const BOM = [0xEF, 0xBB, 0xBF]
+const BOM = '\uFEFF'
 /**
- * @type {10} LF
+ * @type {'\n'} LF
  */
-const LF = 0x0A
+const LF = '\n'
 /**
- * @type {13} CR
+ * @type {'\r'} CR
  */
-const CR = 0x0D
+const CR = '\r'
 /**
- * @type {58} COLON
+ * @type {':'} COLON
  */
-const COLON = 0x3A
+const COLON = ':'
 /**
- * @type {32} SPACE
+ * @type {' '} SPACE
  */
-const SPACE = 0x20
+const SPACE = ' '
 
 /**
  * @typedef {object} EventSourceStreamEvent
@@ -53,21 +54,16 @@ class EventSourceStream extends Transform {
   checkBOM = true
 
   /**
-   * @type {boolean}
+   * Stores the partial line between chunks.
+   * @type {string}
    */
-  crlfCheck = false
+  buffer = ''
 
   /**
-   * @type {boolean}
+   * Decodes UTF-8 without splitting multibyte code points across chunks.
+   * @type {StringDecoder}
    */
-  eventEndCheck = false
-
-  /**
-   * @type {Buffer|null}
-   */
-  buffer = null
-
-  pos = 0
+  decoder = new StringDecoder('utf8')
 
   event = {
     data: undefined,
@@ -107,183 +103,79 @@ class EventSourceStream extends Transform {
       return
     }
 
-    // Cache the chunk in the buffer, as the data might not be complete while
-    // processing it
-    // TODO: Investigate if there is a more performant way to handle
-    // incoming chunks
-    // see: https://github.com/nodejs/undici/issues/2630
-    if (this.buffer) {
-      this.buffer = Buffer.concat([this.buffer, chunk])
-    } else {
-      this.buffer = chunk
+    let data = this.decoder.write(chunk)
+
+    // Wait until the UTF-8 decoder has enough bytes to emit characters.
+    if (data.length === 0) {
+      callback()
+      return
     }
 
-    // Strip leading byte-order-mark if we opened the stream and started
-    // the processing of the incoming data
+    // Strip the leading byte-order-mark once we have decoded the first
+    // characters of the stream.
     if (this.checkBOM) {
-      switch (this.buffer.length) {
-        case 1:
-          // Check if the first byte is the same as the first byte of the BOM
-          if (this.buffer[0] === BOM[0]) {
-            // If it is, we need to wait for more data
-            callback()
-            return
-          }
-          // Set the checkBOM flag to false as we don't need to check for the
-          // BOM anymore
-          this.checkBOM = false
+      this.checkBOM = false
 
-          // The buffer only contains one byte so we need to wait for more data
+      if (data[0] === BOM) {
+        data = data.slice(1)
+
+        if (data.length === 0) {
           callback()
           return
-        case 2:
-          // Check if the first two bytes are the same as the first two bytes
-          // of the BOM
-          if (
-            this.buffer[0] === BOM[0] &&
-            this.buffer[1] === BOM[1]
-          ) {
-            // If it is, we need to wait for more data, because the third byte
-            // is needed to determine if it is the BOM or not
-            callback()
-            return
-          }
-
-          // Set the checkBOM flag to false as we don't need to check for the
-          // BOM anymore
-          this.checkBOM = false
-          break
-        case 3:
-          // Check if the first three bytes are the same as the first three
-          // bytes of the BOM
-          if (
-            this.buffer[0] === BOM[0] &&
-            this.buffer[1] === BOM[1] &&
-            this.buffer[2] === BOM[2]
-          ) {
-            // If it is, we can drop the buffered data, as it is only the BOM
-            this.buffer = Buffer.alloc(0)
-            // Set the checkBOM flag to false as we don't need to check for the
-            // BOM anymore
-            this.checkBOM = false
-
-            // Await more data
-            callback()
-            return
-          }
-          // If it is not the BOM, we can start processing the data
-          this.checkBOM = false
-          break
-        default:
-          // The buffer is longer than 3 bytes, so we can drop the BOM if it is
-          // present
-          if (
-            this.buffer[0] === BOM[0] &&
-            this.buffer[1] === BOM[1] &&
-            this.buffer[2] === BOM[2]
-          ) {
-            // Remove the BOM from the buffer
-            this.buffer = this.buffer.subarray(3)
-          }
-
-          // Set the checkBOM flag to false as we don't need to check for the
-          this.checkBOM = false
-          break
+        }
       }
     }
 
-    while (this.pos < this.buffer.length) {
-      // If the previous line ended with an end-of-line, we need to check
-      // if the next character is also an end-of-line.
-      if (this.eventEndCheck) {
-        // If the the current character is an end-of-line, then the event
-        // is finished and we can process it
-
-        // If the previous line ended with a carriage return, we need to
-        // check if the current character is a line feed and remove it
-        // from the buffer.
-        if (this.crlfCheck) {
-          // If the current character is a line feed, we can remove it
-          // from the buffer and reset the crlfCheck flag
-          if (this.buffer[this.pos] === LF) {
-            this.buffer = this.buffer.subarray(this.pos + 1)
-            this.pos = 0
-            this.crlfCheck = false
-
-            // It is possible that the line feed is not the end of the
-            // event. We need to check if the next character is an
-            // end-of-line character to determine if the event is
-            // finished. We simply continue the loop to check the next
-            // character.
-
-            // As we removed the line feed from the buffer and set the
-            // crlfCheck flag to false, we basically don't make any
-            // distinction between a line feed and a carriage return.
-            continue
-          }
-          this.crlfCheck = false
-        }
-
-        if (this.buffer[this.pos] === LF || this.buffer[this.pos] === CR) {
-          // If the current character is a carriage return, we need to
-          // set the crlfCheck flag to true, as we need to check if the
-          // next character is a line feed so we can remove it from the
-          // buffer
-          if (this.buffer[this.pos] === CR) {
-            this.crlfCheck = true
-          }
-
-          this.buffer = this.buffer.subarray(this.pos + 1)
-          this.pos = 0
-          if (
-            this.event.data !== undefined || this.event.event || this.event.id !== undefined || this.event.retry) {
-            this.processEvent(this.event)
-          }
-          this.clearEvent()
-          continue
-        }
-        // If the current character is not an end-of-line, then the event
-        // is not finished and we have to reset the eventEndCheck flag
-        this.eventEndCheck = false
-        continue
-      }
-
-      // If the current character is an end-of-line, we can process the
-      // line
-      if (this.buffer[this.pos] === LF || this.buffer[this.pos] === CR) {
-        // If the current character is a carriage return, we need to
-        // set the crlfCheck flag to true, as we need to check if the
-        // next character is a line feed
-        if (this.buffer[this.pos] === CR) {
-          this.crlfCheck = true
-        }
-
-        // In any case, we can process the line as we reached an
-        // end-of-line character
-        this.parseLine(this.buffer.subarray(0, this.pos), this.event)
-
-        // Remove the processed line from the buffer
-        this.buffer = this.buffer.subarray(this.pos + 1)
-        // Reset the position as we removed the processed line from the buffer
-        this.pos = 0
-        // A line was processed and this could be the end of the event. We need
-        // to check if the next line is empty to determine if the event is
-        // finished.
-        this.eventEndCheck = true
-        continue
-      }
-
-      this.pos++
+    if (this.buffer.length !== 0) {
+      data = this.buffer + data
     }
 
+    let lineStart = 0
+
+    for (let i = 0; i < data.length; i++) {
+      const char = data[i]
+
+      if (char !== LF && char !== CR) {
+        continue
+      }
+
+      const line = data.slice(lineStart, i)
+
+      if (line.length === 0) {
+        if (
+          this.event.data !== undefined ||
+          this.event.event ||
+          this.event.id !== undefined ||
+          this.event.retry
+        ) {
+          this.processEvent(this.event)
+        }
+
+        this.clearEvent()
+      } else {
+        this.parseLine(line, this.event)
+      }
+
+      if (char === CR && data[i + 1] === LF) {
+        i++
+      }
+
+      lineStart = i + 1
+    }
+
+    this.buffer = data.slice(lineStart)
     callback()
   }
 
   /**
-   * @param {Buffer} line
+   * @param {Buffer|string} line
    * @param {EventSourceStreamEvent} event
    */
   parseLine (line, event) {
+    if (typeof line !== 'string') {
+      line = line.toString('utf8')
+    }
+
     // If the line is empty (a blank line)
     // Dispatch the event, as defined below.
     // This will be handled in the _transform method
@@ -305,10 +197,7 @@ class EventSourceStream extends Transform {
     if (colonPosition !== -1) {
       // Collect the characters on the line before the first U+003A COLON
       // character (:), and let field be that string.
-      // TODO: Investigate if there is a more performant way to extract the
-      // field
-      // see: https://github.com/nodejs/undici/issues/2630
-      field = line.subarray(0, colonPosition).toString('utf8')
+      field = line.slice(0, colonPosition)
 
       // Collect the characters on the line after the first U+003A COLON
       // character (:), and let value be that string.
@@ -317,17 +206,14 @@ class EventSourceStream extends Transform {
       if (line[valueStart] === SPACE) {
         ++valueStart
       }
-      // TODO: Investigate if there is a more performant way to extract the
-      // value
-      // see: https://github.com/nodejs/undici/issues/2630
-      value = line.subarray(valueStart).toString('utf8')
+      value = line.slice(valueStart)
 
       // Otherwise, the string is not empty but does not contain a U+003A COLON
       // character (:)
     } else {
       // Process the field using the steps described below, using the whole
       // line as the field name, and the empty string as the field value.
-      field = line.toString('utf8')
+      field = line
       value = ''
     }
 

--- a/test/eventsource/eventsource-stream-bom.js
+++ b/test/eventsource/eventsource-stream-bom.js
@@ -6,129 +6,153 @@ const { EventSourceStream } = require('../../lib/web/eventsource/eventsource-str
 describe('EventSourceStream - handle BOM', () => {
   test('Remove BOM from the beginning of the stream. 1 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`\uFEFF${dataField}`, 'utf8')
+    const content = Buffer.from(`\uFEFF${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i++) {
       stream.write(Buffer.from([content[i]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 
   test('Remove BOM from the beginning of the stream. 2 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`\uFEFF${dataField}`, 'utf8')
+    const content = Buffer.from(`\uFEFF${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i += 2) {
       stream.write(Buffer.from([content[i], content[i + 1]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 
   test('Remove BOM from the beginning of the stream. 3 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`\uFEFF${dataField}`, 'utf8')
+    const content = Buffer.from(`\uFEFF${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i += 3) {
       stream.write(Buffer.from([content[i], content[i + 1], content[i + 2]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 
   test('Remove BOM from the beginning of the stream. 4 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`\uFEFF${dataField}`, 'utf8')
+    const content = Buffer.from(`\uFEFF${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i += 4) {
       stream.write(Buffer.from([content[i], content[i + 1], content[i + 2], content[i + 3]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 
   test('Not containing BOM from the beginning of the stream. 1 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`${dataField}`, 'utf8')
+    const content = Buffer.from(`${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i += 1) {
       stream.write(Buffer.from([content[i]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 
   test('Not containing BOM from the beginning of the stream. 2 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`${dataField}`, 'utf8')
+    const content = Buffer.from(`${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i += 2) {
       stream.write(Buffer.from([content[i], content[i + 1]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 
   test('Not containing BOM from the beginning of the stream. 3 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`${dataField}`, 'utf8')
+    const content = Buffer.from(`${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i += 3) {
       stream.write(Buffer.from([content[i], content[i + 1], content[i + 2]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 
   test('Not containing BOM from the beginning of the stream. 4 byte chunks', (t) => {
     const dataField = 'data: Hello'
-    const content = Buffer.from(`${dataField}`, 'utf8')
+    const content = Buffer.from(`${dataField}\n`, 'utf8')
 
     const stream = new EventSourceStream()
+    let calls = 0
 
     stream.parseLine = function (line) {
-      t.assert.strictEqual(line.byteLength, dataField.length)
-      t.assert.strictEqual(line.toString(), dataField)
+      calls++
+      t.assert.strictEqual(line, dataField)
     }
 
     for (let i = 0; i < content.length; i += 4) {
       stream.write(Buffer.from([content[i], content[i + 1], content[i + 2], content[i + 3]]))
     }
+
+    t.assert.strictEqual(calls, 1)
   })
 })

--- a/test/eventsource/eventsource-stream.js
+++ b/test/eventsource/eventsource-stream.js
@@ -103,6 +103,24 @@ describe('EventSourceStream', () => {
     }
   })
 
+  test('Should handle UTF-8 characters split across chunks.', (t) => {
+    const content = Buffer.from('data: Grüße 😀\n\n', 'utf8')
+
+    const stream = new EventSourceStream()
+
+    stream.processEvent = function (event) {
+      t.assert.strictEqual(typeof event, 'object')
+      t.assert.strictEqual(event.event, undefined)
+      t.assert.strictEqual(event.data, 'Grüße 😀')
+      t.assert.strictEqual(event.id, undefined)
+      t.assert.strictEqual(event.retry, undefined)
+    }
+
+    for (let i = 0; i < content.length; i++) {
+      stream.write(Buffer.from([content[i]]))
+    }
+  })
+
   test('Should ignore comments', (t) => {
     const content = Buffer.from(':data: Hello\n\n', 'utf8')
 


### PR DESCRIPTION
```
benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• ascii, 1-byte chunks
------------------------------------------- -------------------------------
legacy buffer parser           2.20 ms/iter   2.23 ms    █                 
                        (2.11 ms … 3.08 ms)   2.55 ms █  █                 
                    (501.54 kb …   4.49 mb)   4.37 mb ██▅█▇▆▄▅▄▄▄▁▂▁▁▂▁▁▁▁▁

current decoder parser         3.33 ms/iter   3.35 ms  ▄█                  
                        (3.27 ms … 3.75 ms)   3.57 ms  ██                  
                    (715.86 kb …   2.88 mb) 955.78 kb ▇███▄▃▅▃▅▃▅▂▃▁▂▂▁▁▁▁▁

• ascii, 32-byte chunks
------------------------------------------- -------------------------------
legacy buffer parser         567.22 µs/iter 566.00 µs █                    
                    (548.33 µs … 787.08 µs) 714.50 µs █▆                   
                    ( 92.31 kb … 844.88 kb) 796.24 kb ██▅▄▂▂▁▁▂▂▁▁▁▁▁▂▁▁▁▁▁

current decoder parser       402.99 µs/iter 402.75 µs    █                 
                    (379.63 µs … 621.08 µs) 524.71 µs    █                 
                    ( 82.54 kb …   1.24 mb) 252.31 kb ▃▁▁█▄▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

• utf8 + bom, mixed chunks
------------------------------------------- -------------------------------
legacy buffer parser         804.94 µs/iter 802.79 µs  █                   
                      (785.54 µs … 1.05 ms) 944.29 µs  █▂                  
                    (  1.20 mb …   1.20 mb)   1.20 mb ███▄▃▂▂▂▂▁▁▁▁▁▁▂▁▁▁▁▁

current decoder parser       933.48 µs/iter 952.75 µs  █                   
                      (903.79 µs … 1.23 ms)   1.03 ms ▄█                   
                    (305.06 kb … 536.41 kb) 424.37 kb ██▅▃▂▃▅▇▇▅▄▃▂▁▂▁▁▁▁▂▁

• parseLine, ascii fields
------------------------------------------- -------------------------------
legacy parseLine               1.68 ms/iter   1.69 ms  █                   
                        (1.64 ms … 1.94 ms)   1.91 ms ▄█                   
                    (  1.20 mb …   2.51 mb)   1.85 mb ██▇▄▄▄▃▂▂▂▂▂▂▁▂▂▁▁▁▁▁

current parseLine            369.76 µs/iter 370.58 µs ▇█                   
                    (358.79 µs … 746.08 µs) 463.29 µs ██                   
                    ( 16.48 kb …   1.77 mb) 370.68 kb ██▇▅▃▄▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁

• parseLine, utf8 fields
------------------------------------------- -------------------------------
legacy parseLine               1.81 ms/iter   1.82 ms  ▄█                  
                        (1.75 ms … 2.12 ms)   2.01 ms  ██▄▄▃               
                    (  1.87 mb …   1.87 mb)   1.87 mb ▆██████▇▄▃▂▂▁▂▂▂▂▂▂▂▂

current parseLine            380.42 µs/iter 382.25 µs ▂█                   
                    (367.79 µs … 584.29 µs) 474.08 µs ██                   
                    (368.05 kb … 880.07 kb) 368.38 kb ██▅▆▃▃▃▂▂▁▂▁▁▁▁▁▁▁▁▁▁
```