### PR TITLE
fix(http2): preserve accepted streams after GOAWAY

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -67,7 +67,8 @@ const {
     HTTP2_HEADER_EXPECT,
     HTTP2_HEADER_STATUS,
     HTTP2_HEADER_PROTOCOL,
-    NGHTTP2_NO_ERROR
+    NGHTTP2_NO_ERROR,
+    NGHTTP2_REFUSED_STREAM
   }
 } = http2
 
@@ -135,6 +136,24 @@ function clearRequestStream (request) {
   const cleanup = request[kRequestStreamCleanup]
   detachRequestFromStream(request)
   cleanup?.()
+}
+
+function canRetryRequestAfterGoAway (request) {
+  const { body } = request
+
+  return body == null || util.isBuffer(body) || util.isBlobLike(body)
+}
+
+function closeRequestStream (request, code = NGHTTP2_REFUSED_STREAM) {
+  const stream = request[kRequestStream]
+
+  clearRequestStream(request)
+
+  if (stream != null && !stream.destroyed && !stream.closed) {
+    try {
+      stream.close(code)
+    } catch {}
+  }
 }
 
 function connectH2 (client, socket) {
@@ -376,13 +395,26 @@ function onHttp2SessionGoAway (errorCode, lastStreamID) {
   const client = this[kClient]
   const previousPendingIdx = client[kPendingIdx]
   const pendingIdx = getGoAwayPendingIdx(client, lastStreamID)
+  const retriableRequests = []
 
   for (let i = pendingIdx; i < previousPendingIdx; i++) {
     const request = client[kQueue][i]
 
     if (request != null) {
-      clearRequestStream(request)
+      closeRequestStream(request)
+
+      if (canRetryRequestAfterGoAway(request)) {
+        retriableRequests.push(request)
+      } else {
+        util.errorRequest(client, request, err)
+      }
     }
+  }
+
+  if (pendingIdx !== previousPendingIdx) {
+    const remainingPendingRequests = client[kQueue].slice(previousPendingIdx)
+    client[kQueue].length = pendingIdx
+    client[kQueue].push(...retriableRequests, ...remainingPendingRequests)
   }
 
   if (client[kHTTP2Session] === this) {

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -41,6 +41,8 @@ const {
 const { channels } = require('../core/diagnostics.js')
 
 const kOpenStreams = Symbol('open streams')
+const kRequestStreamId = Symbol('request stream id')
+const kReceivedGoAway = Symbol('received goaway')
 
 let extractBody
 
@@ -62,7 +64,8 @@ const {
     HTTP2_HEADER_CONTENT_LENGTH,
     HTTP2_HEADER_EXPECT,
     HTTP2_HEADER_STATUS,
-    HTTP2_HEADER_PROTOCOL
+    HTTP2_HEADER_PROTOCOL,
+    NGHTTP2_NO_ERROR
   }
 } = http2
 
@@ -84,6 +87,31 @@ function parseH2Headers (headers) {
   }
 
   return result
+}
+
+function getGoAwayError (session, errorCode) {
+  return session[kError] ||
+    (errorCode === NGHTTP2_NO_ERROR
+      ? new InformationalError(`HTTP/2: "GOAWAY" frame received with code ${errorCode}`)
+      : new SocketError(`HTTP/2: "GOAWAY" frame received with code ${errorCode}`, util.getSocketInfo(session[kSocket])))
+}
+
+function getGoAwayPendingIdx (client, lastStreamID) {
+  const maxAcceptedStreamID = Number.isInteger(lastStreamID) ? lastStreamID : Number.MAX_SAFE_INTEGER
+
+  for (let i = client[kRunningIdx]; i < client[kPendingIdx]; i++) {
+    const request = client[kQueue][i]
+
+    if (request == null) {
+      continue
+    }
+
+    if (typeof request[kRequestStreamId] !== 'number' || request[kRequestStreamId] > maxAcceptedStreamID) {
+      return i
+    }
+  }
+
+  return client[kPendingIdx]
 }
 
 function connectH2 (client, socket) {
@@ -111,6 +139,7 @@ function connectH2 (client, socket) {
       interval: client[kPingInterval] === 0 ? null : setInterval(onHttp2SendPing, client[kPingInterval], session).unref()
     }
   }
+  session[kReceivedGoAway] = false
   // We set it to true by default in a best-effort; however once connected to an H2 server
   // we will check if extended CONNECT protocol is supported or not
   // and set this value accordingly.
@@ -311,48 +340,56 @@ function onHttp2SessionEnd () {
  *
  * @this {import('http2').ClientHttp2Session}
  * @param {number} errorCode
+ * @param {number} lastStreamID
  */
-function onHttp2SessionGoAway (errorCode) {
-  // TODO(mcollina): Verify if GOAWAY implements the spec correctly:
-  // https://datatracker.ietf.org/doc/html/rfc7540#section-6.8
-  // Specifically, we do not verify the "valid" stream id.
-
-  const err = this[kError] || new SocketError(`HTTP/2: "GOAWAY" frame received with code ${errorCode}`, util.getSocketInfo(this[kSocket]))
-  const client = this[kClient]
-
-  client[kSocket] = null
-  client[kHTTPContext] = null
-
-  // this is an HTTP2 session
-  this.close()
-  this[kHTTP2Session] = null
-
-  util.destroy(this[kSocket], err)
-
-  // Fail head of pipeline.
-  if (client[kRunningIdx] < client[kQueue].length) {
-    const request = client[kQueue][client[kRunningIdx]]
-    client[kQueue][client[kRunningIdx]++] = null
-    util.errorRequest(client, request, err)
-    client[kPendingIdx] = client[kRunningIdx]
+function onHttp2SessionGoAway (errorCode, lastStreamID) {
+  if (this[kReceivedGoAway]) {
+    return
   }
 
-  assert(client[kRunning] === 0)
+  this[kReceivedGoAway] = true
+
+  const err = getGoAwayError(this, errorCode)
+  const client = this[kClient]
+  const previousPendingIdx = client[kPendingIdx]
+  const pendingIdx = getGoAwayPendingIdx(client, lastStreamID)
+
+  for (let i = pendingIdx; i < previousPendingIdx; i++) {
+    const request = client[kQueue][i]
+
+    if (request != null) {
+      request[kRequestStreamId] = null
+    }
+  }
+
+  if (client[kHTTP2Session] === this) {
+    client[kSocket] = null
+    client[kHTTPContext] = null
+    client[kHTTP2Session] = null
+  }
+
+  if (!this.closed && !this.destroyed) {
+    this.close()
+  }
+
+  client[kPendingIdx] = pendingIdx
 
   client.emit('disconnect', client[kUrl], [client], err)
-  client.emit('connectionError', client[kUrl], [client], err)
 
   client[kResume]()
 }
 
 function onHttp2SessionClose () {
   const { [kClient]: client, [kHTTP2SessionState]: state } = this
-  const { [kSocket]: socket } = client
+  const socket = this[kSocket]
 
-  const err = this[kSocket][kError] || this[kError] || new SocketError('closed', util.getSocketInfo(socket))
+  const err = socket[kError] || this[kError] || new SocketError('closed', util.getSocketInfo(socket))
 
-  client[kSocket] = null
-  client[kHTTPContext] = null
+  if (client[kHTTP2Session] === this) {
+    client[kSocket] = null
+    client[kHTTPContext] = null
+    client[kHTTP2Session] = null
+  }
 
   if (state.ping.interval != null) {
     clearInterval(state.ping.interval)
@@ -376,8 +413,13 @@ function onHttp2SocketClose () {
 
   const client = this[kHTTP2Session][kClient]
 
+  if (client[kSocket] !== this) {
+    return
+  }
+
   client[kSocket] = null
   client[kHTTPContext] = null
+  client[kHTTP2Session] = null
 
   if (this[kHTTP2Session] !== null) {
     this[kHTTP2Session].destroy(err)
@@ -582,6 +624,7 @@ function writeH2 (client, request) {
 
       stream = session.request(headers, { endStream: false, signal })
       stream[kHTTP2Stream] = true
+      request[kRequestStreamId] = stream.id
       setupUpgradeStream(stream)
       return true
     }
@@ -593,6 +636,7 @@ function writeH2 (client, request) {
     // We disabled endStream to allow the user to write to the stream
     stream = session.request(headers, { endStream: false, signal })
     stream[kHTTP2Stream] = true
+    request[kRequestStreamId] = stream.id
     setupUpgradeStream(stream)
 
     return true
@@ -680,6 +724,7 @@ function writeH2 (client, request) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'
     stream = session.request(headers, { endStream: shouldEndStream, signal })
     stream[kHTTP2Stream] = true
+    request[kRequestStreamId] = stream.id
 
     stream.once('continue', writeBodyH2)
   } else {
@@ -688,6 +733,7 @@ function writeH2 (client, request) {
       signal
     })
     stream[kHTTP2Stream] = true
+    request[kRequestStreamId] = stream.id
 
     writeBodyH2()
   }
@@ -698,8 +744,13 @@ function writeH2 (client, request) {
 
   // Track whether we received a response (headers)
   let responseReceived = false
+  const isActiveStream = () => request[kRequestStreamId] === stream.id
 
   stream.once('response', headers => {
+    if (!isActiveStream()) {
+      return
+    }
+
     const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
     request.onResponseStarted()
     responseReceived = true
@@ -730,6 +781,10 @@ function writeH2 (client, request) {
   })
 
   stream.once('end', () => {
+    if (!isActiveStream()) {
+      return
+    }
+
     stream.removeAllListeners('data')
     // If we received a response, this is a normal completion
     if (responseReceived) {
@@ -737,11 +792,13 @@ function writeH2 (client, request) {
         request.onResponseEnd({})
       }
 
+      request[kRequestStreamId] = null
       client[kQueue][client[kRunningIdx]++] = null
       client[kResume]()
     } else {
       // Stream ended without receiving a response - this is an error
       // (e.g., server destroyed the stream before sending headers)
+      request[kRequestStreamId] = null
       abort(new InformationalError('HTTP/2: stream half-closed (remote)'))
       client[kQueue][client[kRunningIdx]++] = null
       client[kPendingIdx] = client[kRunningIdx]
@@ -758,11 +815,19 @@ function writeH2 (client, request) {
   })
 
   stream.once('error', function (err) {
+    if (!isActiveStream()) {
+      return
+    }
+
     stream.removeAllListeners('data')
     abort(err)
   })
 
   stream.once('frameError', (type, code) => {
+    if (!isActiveStream()) {
+      return
+    }
+
     stream.removeAllListeners('data')
     abort(new InformationalError(`HTTP/2: "frameError" received - type ${type}, code ${code}`))
   })
@@ -772,12 +837,20 @@ function writeH2 (client, request) {
   })
 
   stream.on('timeout', () => {
+    if (!isActiveStream()) {
+      return
+    }
+
     const err = new InformationalError(`HTTP/2: "stream timeout after ${requestTimeout}"`)
     stream.removeAllListeners('data')
     abort(err)
   })
 
   stream.once('trailers', trailers => {
+    if (!isActiveStream()) {
+      return
+    }
+
     if (request.aborted || request.completed) {
       return
     }

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -605,7 +605,7 @@ function writeH2 (client, request) {
       }
 
       const releaseUpgradeStream = () => {
-        if (request[kRequestStreamCleanup] === releaseUpgradeStream && request[kRequestStream] === stream) {
+        if (request[kRequestStream] === stream) {
           detachRequestFromStream(request)
         }
 
@@ -836,7 +836,7 @@ function writeH2 (client, request) {
   }
 
   const releaseRequestStream = () => {
-    if (request[kRequestStreamCleanup] === releaseRequestStream && request[kRequestStream] === stream) {
+    if (request[kRequestStream] === stream) {
       detachRequestFromStream(request)
     }
 

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -830,6 +830,7 @@ function writeH2 (client, request) {
     stream.off('end', onEnd)
     stream.off('error', onError)
     stream.off('frameError', onFrameError)
+    stream.off('aborted', onAborted)
     stream.off('timeout', onTimeout)
     stream.off('trailers', onTrailers)
     stream.off('data', onData)
@@ -912,9 +913,9 @@ function writeH2 (client, request) {
     abort(new InformationalError(`HTTP/2: "frameError" received - type ${type}, code ${code}`))
   }
 
-  stream.on('aborted', () => {
+  const onAborted = () => {
     stream.off('data', onData)
-  })
+  }
 
   const onTimeout = () => {
     releaseRequestStream()
@@ -943,6 +944,7 @@ function writeH2 (client, request) {
   stream.once('end', onEnd)
   stream.once('error', onError)
   stream.once('frameError', onFrameError)
+  stream.on('aborted', onAborted)
   stream.on('timeout', onTimeout)
   stream.once('trailers', onTrailers)
 

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -435,8 +435,7 @@ function onHttp2SessionGoAway (errorCode, lastStreamID) {
 }
 
 function onHttp2SessionClose () {
-  const { [kClient]: client, [kHTTP2SessionState]: state } = this
-  const socket = this[kSocket]
+  const { [kClient]: client, [kHTTP2SessionState]: state, [kSocket]: socket } = this
 
   const err = socket[kError] || this[kError] || new SocketError('closed', util.getSocketInfo(socket))
 
@@ -485,9 +484,7 @@ function onHttp2SocketClose () {
     client[kHTTP2Session] = null
   }
 
-  if (session !== null) {
-    session.destroy(err)
-  }
+  session.destroy(err)
 
   client[kPendingIdx] = client[kRunningIdx]
 

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -42,6 +42,7 @@ const { channels } = require('../core/diagnostics.js')
 
 const kOpenStreams = Symbol('open streams')
 const kRequestStreamId = Symbol('request stream id')
+const kRequestStreamCleanup = Symbol('request stream cleanup')
 const kReceivedGoAway = Symbol('received goaway')
 
 let extractBody
@@ -112,6 +113,21 @@ function getGoAwayPendingIdx (client, lastStreamID) {
   }
 
   return client[kPendingIdx]
+}
+
+function bindRequestToStream (request, streamId, cleanup) {
+  const previousCleanup = request[kRequestStreamCleanup]
+  request[kRequestStreamCleanup] = null
+  previousCleanup?.()
+  request[kRequestStreamId] = streamId
+  request[kRequestStreamCleanup] = cleanup
+}
+
+function clearRequestStream (request) {
+  const cleanup = request[kRequestStreamCleanup]
+  request[kRequestStreamCleanup] = null
+  request[kRequestStreamId] = null
+  cleanup?.()
 }
 
 function connectH2 (client, socket) {
@@ -358,7 +374,7 @@ function onHttp2SessionGoAway (errorCode, lastStreamID) {
     const request = client[kQueue][i]
 
     if (request != null) {
-      request[kRequestStreamId] = null
+      clearRequestStream(request)
     }
   }
 
@@ -513,7 +529,23 @@ function writeH2 (client, request) {
   headers[HTTP2_HEADER_AUTHORITY] = host || `${hostname}${port ? `:${port}` : ''}`
   headers[HTTP2_HEADER_METHOD] = method
 
-  const abort = (err) => {
+  let requestFinalized = false
+  const finalizeRequest = (resetPendingIdx = false) => {
+    if (requestFinalized) {
+      return
+    }
+
+    requestFinalized = true
+    client[kQueue][client[kRunningIdx]++] = null
+
+    if (resetPendingIdx) {
+      client[kPendingIdx] = client[kRunningIdx]
+    }
+
+    client[kResume]()
+  }
+
+  const abort = (err, resetPendingIdx = false) => {
     if (request.aborted || request.completed) {
       return
     }
@@ -523,16 +555,14 @@ function writeH2 (client, request) {
     util.errorRequest(client, request, err)
 
     if (stream != null) {
-      // Some chunks might still come after abort,
-      // let's ignore them
-      stream.removeAllListeners('data')
+      clearRequestStream(request)
 
       // On Abort, we close the stream to send RST_STREAM frame
       stream.close()
 
       // We move the running index to the next request
       client[kOnError](err)
-      client[kResume]()
+      finalizeRequest(resetPendingIdx)
     }
 
     // We do not destroy the socket as we can continue using the session
@@ -633,7 +663,7 @@ function writeH2 (client, request) {
 
       stream = session.request(headers, { endStream: false, signal })
       stream[kHTTP2Stream] = true
-      request[kRequestStreamId] = stream.id
+      bindRequestToStream(request, stream.id, null)
       setupUpgradeStream(stream)
       return true
     }
@@ -645,7 +675,7 @@ function writeH2 (client, request) {
     // We disabled endStream to allow the user to write to the stream
     stream = session.request(headers, { endStream: false, signal })
     stream[kHTTP2Stream] = true
-    request[kRequestStreamId] = stream.id
+    bindRequestToStream(request, stream.id, null)
     setupUpgradeStream(stream)
 
     return true
@@ -733,18 +763,14 @@ function writeH2 (client, request) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'
     stream = session.request(headers, { endStream: shouldEndStream, signal })
     stream[kHTTP2Stream] = true
-    request[kRequestStreamId] = stream.id
-
-    stream.once('continue', writeBodyH2)
+    bindRequestToStream(request, stream.id, null)
   } else {
     stream = session.request(headers, {
       endStream: shouldEndStream,
       signal
     })
     stream[kHTTP2Stream] = true
-    request[kRequestStreamId] = stream.id
-
-    writeBodyH2()
+    bindRequestToStream(request, stream.id, null)
   }
 
   // Increment counter as we have new streams open
@@ -753,12 +779,40 @@ function writeH2 (client, request) {
 
   // Track whether we received a response (headers)
   let responseReceived = false
-  const isActiveStream = () => request[kRequestStreamId] === stream.id
-
-  stream.once('response', headers => {
-    if (!isActiveStream()) {
+  const onData = (chunk) => {
+    if (request.aborted || request.completed) {
       return
     }
+
+    if (request.onResponseData(chunk) === false) {
+      stream.pause()
+    }
+  }
+
+  const removeRequestStreamListeners = () => {
+    stream.off('continue', writeBodyH2)
+    stream.off('response', onResponse)
+    stream.off('end', onEnd)
+    stream.off('error', onError)
+    stream.off('frameError', onFrameError)
+    stream.off('timeout', onTimeout)
+    stream.off('trailers', onTrailers)
+    stream.off('data', onData)
+  }
+
+  const releaseRequestStream = () => {
+    if (request[kRequestStreamCleanup] === removeRequestStreamListeners) {
+      request[kRequestStreamCleanup] = null
+      if (request[kRequestStreamId] === stream.id) {
+        request[kRequestStreamId] = null
+      }
+    }
+
+    removeRequestStreamListeners()
+  }
+
+  const onResponse = (headers) => {
+    stream.off('response', onResponse)
 
     const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
     request.onResponseStarted()
@@ -770,7 +824,7 @@ function writeH2 (client, request) {
     // for those scenarios, best effort is to destroy the stream immediately
     // as there's no value to keep it open.
     if (request.aborted) {
-      stream.removeAllListeners('data')
+      releaseRequestStream()
       return
     }
 
@@ -778,94 +832,84 @@ function writeH2 (client, request) {
       stream.pause()
     }
 
-    stream.on('data', (chunk) => {
-      if (request.aborted || request.completed) {
-        return
-      }
+    stream.on('data', onData)
+  }
 
-      if (request.onResponseData(chunk) === false) {
-        stream.pause()
-      }
-    })
-  })
+  const onEnd = () => {
+    stream.off('end', onEnd)
 
-  stream.once('end', () => {
-    if (!isActiveStream()) {
-      return
-    }
-
-    stream.removeAllListeners('data')
+    releaseRequestStream()
     // If we received a response, this is a normal completion
     if (responseReceived) {
       if (!request.aborted && !request.completed) {
         request.onResponseEnd({})
       }
 
-      request[kRequestStreamId] = null
-      client[kQueue][client[kRunningIdx]++] = null
-      client[kResume]()
+      finalizeRequest()
     } else {
       // Stream ended without receiving a response - this is an error
       // (e.g., server destroyed the stream before sending headers)
-      request[kRequestStreamId] = null
-      abort(new InformationalError('HTTP/2: stream half-closed (remote)'))
-      client[kQueue][client[kRunningIdx]++] = null
-      client[kPendingIdx] = client[kRunningIdx]
-      client[kResume]()
+      abort(new InformationalError('HTTP/2: stream half-closed (remote)'), true)
     }
-  })
+  }
 
   stream.once('close', () => {
-    stream.removeAllListeners('data')
+    stream.off('data', onData)
     session[kOpenStreams] -= 1
     if (session[kOpenStreams] === 0) {
       session.unref()
     }
   })
 
-  stream.once('error', function (err) {
-    if (!isActiveStream()) {
-      return
-    }
+  const onError = function (err) {
+    stream.off('error', onError)
 
-    stream.removeAllListeners('data')
+    releaseRequestStream()
     abort(err)
-  })
+  }
 
-  stream.once('frameError', (type, code) => {
-    if (!isActiveStream()) {
-      return
-    }
+  const onFrameError = (type, code) => {
+    stream.off('frameError', onFrameError)
 
-    stream.removeAllListeners('data')
+    releaseRequestStream()
     abort(new InformationalError(`HTTP/2: "frameError" received - type ${type}, code ${code}`))
-  })
+  }
 
   stream.on('aborted', () => {
-    stream.removeAllListeners('data')
+    stream.off('data', onData)
   })
 
-  stream.on('timeout', () => {
-    if (!isActiveStream()) {
-      return
-    }
+  const onTimeout = () => {
+    releaseRequestStream()
 
     const err = new InformationalError(`HTTP/2: "stream timeout after ${requestTimeout}"`)
-    stream.removeAllListeners('data')
     abort(err)
-  })
+  }
 
-  stream.once('trailers', trailers => {
-    if (!isActiveStream()) {
-      return
-    }
+  const onTrailers = (trailers) => {
+    stream.off('trailers', onTrailers)
 
     if (request.aborted || request.completed) {
       return
     }
 
     request.onResponseEnd(trailers)
-  })
+  }
+
+  bindRequestToStream(request, stream.id, removeRequestStreamListeners)
+  if (expectContinue) {
+    stream.once('continue', writeBodyH2)
+  }
+  stream.once('response', onResponse)
+  stream.once('end', onEnd)
+  stream.once('error', onError)
+  stream.once('frameError', onFrameError)
+  stream.on('timeout', onTimeout)
+  stream.once('trailers', onTrailers)
+
+  if (!expectContinue) {
+    writeBodyH2()
+  }
 
   return true
 

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -42,6 +42,7 @@ const { channels } = require('../core/diagnostics.js')
 
 const kOpenStreams = Symbol('open streams')
 const kRequestStreamId = Symbol('request stream id')
+const kRequestStream = Symbol('request stream')
 const kRequestStreamCleanup = Symbol('request stream cleanup')
 const kReceivedGoAway = Symbol('received goaway')
 
@@ -115,18 +116,24 @@ function getGoAwayPendingIdx (client, lastStreamID) {
   return client[kPendingIdx]
 }
 
-function bindRequestToStream (request, streamId, cleanup) {
-  const previousCleanup = request[kRequestStreamCleanup]
+function detachRequestFromStream (request) {
+  request[kRequestStreamId] = null
+  request[kRequestStream] = null
   request[kRequestStreamCleanup] = null
+}
+
+function bindRequestToStream (request, stream, cleanup) {
+  const previousCleanup = request[kRequestStreamCleanup]
+  detachRequestFromStream(request)
   previousCleanup?.()
-  request[kRequestStreamId] = streamId
+  request[kRequestStreamId] = stream.id
+  request[kRequestStream] = stream
   request[kRequestStreamCleanup] = cleanup
 }
 
 function clearRequestStream (request) {
   const cleanup = request[kRequestStreamCleanup]
-  request[kRequestStreamCleanup] = null
-  request[kRequestStreamId] = null
+  detachRequestFromStream(request)
   cleanup?.()
 }
 
@@ -598,11 +605,8 @@ function writeH2 (client, request) {
       }
 
       const releaseUpgradeStream = () => {
-        if (request[kRequestStreamCleanup] === releaseUpgradeStream) {
-          request[kRequestStreamCleanup] = null
-          if (request[kRequestStreamId] === stream.id) {
-            request[kRequestStreamId] = null
-          }
+        if (request[kRequestStreamCleanup] === releaseUpgradeStream && request[kRequestStream] === stream) {
+          detachRequestFromStream(request)
         }
 
         removeUpgradeStreamListeners()
@@ -649,12 +653,11 @@ function writeH2 (client, request) {
         }
 
         removeUpgradeStreamListeners()
-        request[kRequestStreamCleanup] = null
-        request[kRequestStreamId] = null
+        detachRequestFromStream(request)
         finalizeRequest()
       }
 
-      bindRequestToStream(request, stream.id, releaseUpgradeStream)
+      bindRequestToStream(request, stream, releaseUpgradeStream)
       stream.once('response', onUpgradeResponse)
       stream.on('error', onUpgradeStreamError)
       stream.once('end', onUpgradeStreamEnd)
@@ -793,14 +796,14 @@ function writeH2 (client, request) {
     headers[HTTP2_HEADER_EXPECT] = '100-continue'
     stream = session.request(headers, { endStream: shouldEndStream, signal })
     stream[kHTTP2Stream] = true
-    bindRequestToStream(request, stream.id, null)
+    bindRequestToStream(request, stream, null)
   } else {
     stream = session.request(headers, {
       endStream: shouldEndStream,
       signal
     })
     stream[kHTTP2Stream] = true
-    bindRequestToStream(request, stream.id, null)
+    bindRequestToStream(request, stream, null)
   }
 
   // Increment counter as we have new streams open
@@ -833,11 +836,8 @@ function writeH2 (client, request) {
   }
 
   const releaseRequestStream = () => {
-    if (request[kRequestStreamCleanup] === removeRequestStreamListeners) {
-      request[kRequestStreamCleanup] = null
-      if (request[kRequestStreamId] === stream.id) {
-        request[kRequestStreamId] = null
-      }
+    if (request[kRequestStreamCleanup] === releaseRequestStream && request[kRequestStream] === stream) {
+      detachRequestFromStream(request)
     }
 
     removeRequestStreamListeners()
@@ -935,7 +935,7 @@ function writeH2 (client, request) {
     finalizeRequest()
   }
 
-  bindRequestToStream(request, stream.id, releaseRequestStream)
+  bindRequestToStream(request, stream, releaseRequestStream)
   if (expectContinue) {
     stream.once('continue', writeBodyH2)
   }

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -587,16 +587,38 @@ function writeH2 (client, request) {
 
     const setupUpgradeStream = (stream) => {
       let responseReceived = false
+      const onDetachedUpgradeStreamError = () => {}
+
+      const removeUpgradeStreamListeners = () => {
+        stream.off('response', onUpgradeResponse)
+        stream.off('error', onUpgradeStreamError)
+        stream.off('end', onUpgradeStreamEnd)
+        stream.off('timeout', onUpgradeStreamTimeout)
+        stream.off('error', onDetachedUpgradeStreamError)
+      }
+
+      const releaseUpgradeStream = () => {
+        if (request[kRequestStreamCleanup] === releaseUpgradeStream) {
+          request[kRequestStreamCleanup] = null
+          if (request[kRequestStreamId] === stream.id) {
+            request[kRequestStreamId] = null
+          }
+        }
+
+        removeUpgradeStreamListeners()
+
+        if (!stream.destroyed && !stream.closed) {
+          stream.once('error', onDetachedUpgradeStreamError)
+        }
+      }
 
       const failUpgradeStream = (err) => {
         if (responseReceived || request.aborted || request.completed) {
           return
         }
 
-        abort(err)
-        client[kQueue][client[kRunningIdx]++] = null
-        client[kPendingIdx] = client[kRunningIdx]
-        client[kResume]()
+        releaseUpgradeStream()
+        abort(err, true)
       }
 
       const onUpgradeStreamError = () => {
@@ -611,24 +633,34 @@ function writeH2 (client, request) {
         failUpgradeStream(new InformationalError('HTTP/2: stream half-closed (remote)'))
       }
 
-      stream.once('response', (headers, _flags) => {
+      const onUpgradeStreamTimeout = () => {
+        failUpgradeStream(new InformationalError(`HTTP/2: "stream timeout after ${requestTimeout}"`))
+      }
+
+      const onUpgradeResponse = (headers, _flags) => {
         responseReceived = true
 
         const { [HTTP2_HEADER_STATUS]: statusCode, ...realHeaders } = headers
 
         request.onRequestUpgrade(statusCode, parseH2Headers(realHeaders), stream)
 
-        if (!request.aborted && !request.completed) {
-          stream.off('error', onUpgradeStreamError)
-          stream.off('end', onUpgradeStreamEnd)
+        if (request.aborted || request.completed) {
+          return
         }
 
-        client[kQueue][client[kRunningIdx]++] = null
-      })
+        removeUpgradeStreamListeners()
+        request[kRequestStreamCleanup] = null
+        request[kRequestStreamId] = null
+        finalizeRequest()
+      }
 
+      bindRequestToStream(request, stream.id, releaseUpgradeStream)
+      stream.once('response', onUpgradeResponse)
       stream.on('error', onUpgradeStreamError)
       stream.once('end', onUpgradeStreamEnd)
+      stream.on('timeout', onUpgradeStreamTimeout)
       stream.once('close', () => {
+        stream.off('error', onDetachedUpgradeStreamError)
         failUpgradeStream(new InformationalError('HTTP/2: stream closed before response headers'))
 
         session[kOpenStreams] -= 1
@@ -663,7 +695,6 @@ function writeH2 (client, request) {
 
       stream = session.request(headers, { endStream: false, signal })
       stream[kHTTP2Stream] = true
-      bindRequestToStream(request, stream.id, null)
       setupUpgradeStream(stream)
       return true
     }
@@ -675,7 +706,6 @@ function writeH2 (client, request) {
     // We disabled endStream to allow the user to write to the stream
     stream = session.request(headers, { endStream: false, signal })
     stream[kHTTP2Stream] = true
-    bindRequestToStream(request, stream.id, null)
     setupUpgradeStream(stream)
 
     return true
@@ -905,7 +935,7 @@ function writeH2 (client, request) {
     finalizeRequest()
   }
 
-  bindRequestToStream(request, stream.id, removeRequestStreamListeners)
+  bindRequestToStream(request, stream.id, releaseRequestStream)
   if (expectContinue) {
     stream.once('continue', writeBodyH2)
   }

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -779,6 +779,7 @@ function writeH2 (client, request) {
 
   // Track whether we received a response (headers)
   let responseReceived = false
+  const onDetachedStreamError = () => {}
   const onData = (chunk) => {
     if (request.aborted || request.completed) {
       return
@@ -790,6 +791,7 @@ function writeH2 (client, request) {
   }
 
   const removeRequestStreamListeners = () => {
+    stream.off('error', onDetachedStreamError)
     stream.off('continue', writeBodyH2)
     stream.off('response', onResponse)
     stream.off('end', onEnd)
@@ -809,6 +811,10 @@ function writeH2 (client, request) {
     }
 
     removeRequestStreamListeners()
+
+    if (!stream.destroyed && !stream.closed) {
+      stream.once('error', onDetachedStreamError)
+    }
   }
 
   const onResponse = (headers) => {
@@ -855,6 +861,7 @@ function writeH2 (client, request) {
 
   stream.once('close', () => {
     stream.off('data', onData)
+    stream.off('error', onDetachedStreamError)
     session[kOpenStreams] -= 1
     if (session[kOpenStreams] === 0) {
       session.unref()
@@ -893,7 +900,9 @@ function writeH2 (client, request) {
       return
     }
 
+    releaseRequestStream()
     request.onResponseEnd(trailers)
+    finalizeRequest()
   }
 
   bindRequestToStream(request, stream.id, removeRequestStreamListeners)

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -411,18 +411,27 @@ function onHttp2SessionClose () {
 function onHttp2SocketClose () {
   const err = this[kError] || new SocketError('closed', util.getSocketInfo(this))
 
-  const client = this[kHTTP2Session][kClient]
+  const session = this[kHTTP2Session]
+  const client = session[kClient]
 
   if (client[kSocket] !== this) {
-    return
+    // Ignore stale socket closes from a detached GOAWAY session and from any
+    // session that has already been replaced. If the session was detached
+    // without a GOAWAY and there is no replacement yet, we still need the
+    // close event to flush the client state.
+    if (session[kReceivedGoAway] || (client[kHTTP2Session] != null && client[kHTTP2Session] !== session)) {
+      return
+    }
   }
 
   client[kSocket] = null
   client[kHTTPContext] = null
-  client[kHTTP2Session] = null
+  if (client[kHTTP2Session] === session) {
+    client[kHTTP2Session] = null
+  }
 
-  if (this[kHTTP2Session] !== null) {
-    this[kHTTP2Session].destroy(err)
+  if (session !== null) {
+    session.destroy(err)
   }
 
   client[kPendingIdx] = client[kRunningIdx]

--- a/test/h2c-client.js
+++ b/test/h2c-client.js
@@ -95,12 +95,16 @@ test('Should reject request if not h2c supported', async t => {
   await once(server, 'listening')
   const client = new H2CClient(`http://localhost:${server.address().port}/`)
 
-  t.after(() => client.close())
+  t.after(() => client.destroy())
   t.after(() => server.close())
 
-  planner.rejects(
+  await planner.rejects(
     client.request({ path: '/', method: 'GET' }),
-    'SocketError: other side closed'
+    {
+      name: 'SocketError',
+      code: 'UND_ERR_SOCKET',
+      message: 'other side closed'
+    }
   )
 })
 

--- a/test/h2c-client.js
+++ b/test/h2c-client.js
@@ -106,6 +106,18 @@ test('Should reject request if not h2c supported', async t => {
       message: 'other side closed'
     }
   )
+
+  let closeTimer = null
+  try {
+    await Promise.race([
+      client.close(),
+      new Promise((resolve, reject) => {
+        closeTimer = setTimeout(() => reject(new Error('client.close() did not resolve')), 1000)
+      })
+    ])
+  } finally {
+    clearTimeout(closeTimer)
+  }
 })
 
 test('Connect to h2c server over a unix domain socket', { skip: process.platform === 'win32' }, async t => {

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -545,7 +545,7 @@ test('Should handle h2 request without body', async t => {
 })
 
 test('Should clear h2 request stream references before completing a response', async t => {
-  t = tspl(t, { plan: 4 })
+  t = tspl(t, { plan: 6 })
 
   const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
 
@@ -570,6 +570,7 @@ test('Should clear h2 request stream references before completing a response', a
 
   let requestStreamIdSymbol = null
   let requestStreamSymbol = null
+  let requestStreamCleanupSymbol = null
 
   client.dispatch({
     path: '/',
@@ -581,9 +582,11 @@ test('Should clear h2 request stream references before completing a response', a
       const symbols = Object.getOwnPropertySymbols(request)
       requestStreamIdSymbol = symbols.find((symbol) => symbol.description === 'request stream id')
       requestStreamSymbol = symbols.find((symbol) => symbol.description === 'request stream')
+      requestStreamCleanupSymbol = symbols.find((symbol) => symbol.description === 'request stream cleanup')
 
       t.ok(requestStreamIdSymbol)
       t.ok(requestStreamSymbol)
+      t.ok(requestStreamCleanupSymbol)
     },
     onResponseData () {
       return true
@@ -593,6 +596,7 @@ test('Should clear h2 request stream references before completing a response', a
 
       t.strictEqual(request[requestStreamIdSymbol], null)
       t.strictEqual(request[requestStreamSymbol], null)
+      t.strictEqual(request[requestStreamCleanupSymbol], null)
     },
     onResponseError (_controller, err) {
       t.ifError(err)

--- a/test/http2-dispatcher.js
+++ b/test/http2-dispatcher.js
@@ -11,6 +11,7 @@ const { tspl } = require('@matteo.collina/tspl')
 const pem = require('@metcoder95/https-pem')
 
 const { Client, errors } = require('..')
+const { kQueue, kRunningIdx } = require('../lib/core/symbols')
 
 test('Dispatcher#Stream', async t => {
   t = tspl(t, { plan: 4 })
@@ -539,6 +540,64 @@ test('Should handle h2 request without body', async t => {
   t.strictEqual(Buffer.concat(responseBody).toString('utf-8'), 'hello h2!')
   t.strictEqual(requestChunks.length, 0)
   t.strictEqual(Buffer.concat(requestChunks).toString('utf-8'), expectedBody)
+
+  await t.completed
+})
+
+test('Should clear h2 request stream references before completing a response', async t => {
+  t = tspl(t, { plan: 4 })
+
+  const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
+
+  server.on('stream', (stream) => {
+    stream.respond({ ':status': 200 }, { waitForTrailers: true })
+    stream.on('wantTrailers', () => {
+      stream.sendTrailers({ 'x-trailer': 'done' })
+    })
+    stream.end('hello h2!')
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    allowH2: true
+  })
+  after(() => client.close())
+
+  let requestStreamIdSymbol = null
+  let requestStreamSymbol = null
+
+  client.dispatch({
+    path: '/',
+    method: 'GET'
+  }, {
+    onRequestStart () {},
+    onResponseStart () {
+      const request = client[kQueue][client[kRunningIdx]]
+      const symbols = Object.getOwnPropertySymbols(request)
+      requestStreamIdSymbol = symbols.find((symbol) => symbol.description === 'request stream id')
+      requestStreamSymbol = symbols.find((symbol) => symbol.description === 'request stream')
+
+      t.ok(requestStreamIdSymbol)
+      t.ok(requestStreamSymbol)
+    },
+    onResponseData () {
+      return true
+    },
+    onResponseEnd () {
+      const request = client[kQueue][client[kRunningIdx]]
+
+      t.strictEqual(request[requestStreamIdSymbol], null)
+      t.strictEqual(request[requestStreamSymbol], null)
+    },
+    onResponseError (_controller, err) {
+      t.ifError(err)
+    }
+  })
 
   await t.completed
 })

--- a/test/http2-goaway-retry-body.js
+++ b/test/http2-goaway-retry-body.js
@@ -1,0 +1,159 @@
+'use strict'
+
+const { test } = require('node:test')
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const Module = require('node:module')
+const { PassThrough } = require('node:stream')
+
+const {
+  kClient,
+  kPendingIdx,
+  kRunningIdx,
+  kQueue,
+  kSocket,
+  kHTTPContext,
+  kHTTP2Session,
+  kResume
+} = require('../lib/core/symbols')
+
+function loadClientH2Internals () {
+  const filename = path.join(__dirname, '../lib/dispatcher/client-h2.js')
+  const source = fs.readFileSync(filename, 'utf8') + `
+module.exports.__test = {
+  onHttp2SessionGoAway,
+  kReceivedGoAway,
+  kRequestStream,
+  kRequestStreamId,
+  kRequestStreamCleanup
+}
+`
+
+  const mod = new Module(filename)
+  mod.filename = filename
+  mod.paths = Module._nodeModulePaths(path.dirname(filename))
+  mod._compile(source, filename)
+  return mod.exports.__test
+}
+
+test('h2: GOAWAY resets unaccepted streams and only requeues replayable requests', () => {
+  const {
+    onHttp2SessionGoAway,
+    kReceivedGoAway,
+    kRequestStream,
+    kRequestStreamId,
+    kRequestStreamCleanup
+  } = loadClientH2Internals()
+
+  const disconnects = []
+  let resumed = 0
+
+  const client = {
+    [kRunningIdx]: 0,
+    [kPendingIdx]: 3,
+    [kQueue]: [],
+    [kSocket]: { marker: 'socket' },
+    [kHTTPContext]: { marker: 'context' },
+    [kHTTP2Session]: null,
+    [kResume]: () => { resumed++ },
+    emit: (...args) => disconnects.push(args)
+  }
+
+  const acceptedRequest = {
+    [kRequestStreamId]: 1
+  }
+
+  const replayableStream = {
+    destroyed: false,
+    closed: false,
+    closeCode: null,
+    close (code) {
+      this.closeCode = code
+      this.closed = true
+    }
+  }
+
+  const replayableRequest = {
+    body: Buffer.from('payload'),
+    aborted: false,
+    completed: false,
+    [kRequestStreamId]: 3,
+    [kRequestStream]: replayableStream,
+    [kRequestStreamCleanup]: () => {
+      replayableRequest.cleanupCalled = true
+    }
+  }
+
+  const streamingBody = new PassThrough()
+  const streamingStream = {
+    destroyed: false,
+    closed: false,
+    closeCode: null,
+    close (code) {
+      this.closeCode = code
+      this.closed = true
+    }
+  }
+
+  const streamingRequest = {
+    body: streamingBody,
+    aborted: false,
+    completed: false,
+    error: null,
+    [kRequestStreamId]: 5,
+    [kRequestStream]: streamingStream,
+    [kRequestStreamCleanup]: () => {
+      streamingRequest.cleanupCalled = true
+    },
+    onResponseError (err) {
+      this.aborted = true
+      this.error = err
+    }
+  }
+
+  const pendingRequest = {
+    pending: true
+  }
+
+  client[kQueue] = [acceptedRequest, replayableRequest, streamingRequest, pendingRequest]
+
+  const session = {
+    closed: false,
+    destroyed: false,
+    [kClient]: client,
+    [kSocket]: client[kSocket],
+    [kReceivedGoAway]: false,
+    close () {
+      this.closed = true
+    }
+  }
+
+  client[kHTTP2Session] = session
+
+  onHttp2SessionGoAway.call(session, 0, 1)
+
+  assert.strictEqual(replayableStream.closeCode, 7)
+  assert.strictEqual(streamingStream.closeCode, 7)
+  assert.strictEqual(replayableRequest.cleanupCalled, true)
+  assert.strictEqual(streamingRequest.cleanupCalled, true)
+
+  assert.strictEqual(replayableRequest[kRequestStream], null)
+  assert.strictEqual(replayableRequest[kRequestStreamId], null)
+  assert.strictEqual(replayableRequest[kRequestStreamCleanup], null)
+
+  assert.strictEqual(streamingRequest[kRequestStream], null)
+  assert.strictEqual(streamingRequest[kRequestStreamId], null)
+  assert.strictEqual(streamingRequest[kRequestStreamCleanup], null)
+  assert.strictEqual(streamingRequest.aborted, true)
+  assert.strictEqual(streamingRequest.error.message, 'HTTP/2: "GOAWAY" frame received with code 0')
+
+  assert.deepStrictEqual(client[kQueue], [acceptedRequest, replayableRequest, pendingRequest])
+  assert.strictEqual(client[kPendingIdx], 1)
+  assert.strictEqual(client[kSocket], null)
+  assert.strictEqual(client[kHTTPContext], null)
+  assert.strictEqual(client[kHTTP2Session], null)
+  assert.strictEqual(session.closed, true)
+  assert.strictEqual(resumed, 1)
+  assert.strictEqual(disconnects.length, 1)
+})

--- a/test/http2-goaway.js
+++ b/test/http2-goaway.js
@@ -168,6 +168,8 @@ test('#5089 - Handle GOAWAY Gracefully', async (t) => {
   })
 
   server.on('stream', (stream) => {
+    stream.on('error', () => {})
+
     const count = sessionCounts.get(stream.session) + 1
     sessionCounts.set(stream.session, count)
 

--- a/test/http2-goaway.js
+++ b/test/http2-goaway.js
@@ -10,7 +10,7 @@ const pem = require('@metcoder95/https-pem')
 const { Client } = require('..')
 
 test('#3046 - GOAWAY Frame', async t => {
-  t = tspl(t, { plan: 10 })
+  t = tspl(t, { plan: 8 })
 
   const server = createSecureServer(await pem.generate({ opts: { keySize: 2048 } }))
 
@@ -44,16 +44,15 @@ test('#3046 - GOAWAY Frame', async t => {
   })
   after(() => client.close())
 
+  client.on('connectionError', () => {
+    t.fail('unexpected connectionError')
+  })
+
   client.on('disconnect', (url, disconnectClient, err) => {
     t.ok(url instanceof URL)
     t.deepStrictEqual(disconnectClient, [client])
     t.strictEqual(err.message, 'HTTP/2: "GOAWAY" frame received with code 0')
-  })
-
-  client.on('connectionError', (url, disconnectClient, err) => {
-    t.ok(url instanceof URL)
-    t.deepStrictEqual(disconnectClient, [client])
-    t.strictEqual(err.message, 'HTTP/2: "GOAWAY" frame received with code 0')
+    t.strictEqual(err.code, 'UND_ERR_INFO')
   })
 
   const response = await client.request({
@@ -67,11 +66,7 @@ test('#3046 - GOAWAY Frame', async t => {
   t.strictEqual(response.headers['content-type'], 'text/plain; charset=utf-8')
   t.strictEqual(response.headers['x-custom-h2'], 'hello')
   t.strictEqual(response.statusCode, 200)
-
-  await t.rejects(response.body.text(), {
-    message: 'HTTP/2: "GOAWAY" frame received with code 0',
-    code: 'UND_ERR_SOCKET'
-  })
+  t.strictEqual(await response.body.text(), 'Hello World')
 
   await t.completed
 })
@@ -96,16 +91,16 @@ test('#3753 - Handle GOAWAY Gracefully', async (t) => {
     stream.on('error', () => {})
     if (counter === 9 && session != null) {
       session.goaway()
-      stream.end()
-    } else {
-      stream.respond({
-        'content-type': 'text/plain',
-        ':status': 200
-      })
-      setTimeout(() => {
-        stream.end('hello world')
-      }, 150)
     }
+
+    stream.respond({
+      'content-type': 'text/plain',
+      ':status': 200
+    })
+    setTimeout(() => {
+      if (stream.closed) return
+      stream.end('hello world')
+    }, 150)
   })
 
   after(() => server.close())
@@ -130,7 +125,7 @@ test('#3753 - Handle GOAWAY Gracefully', async (t) => {
     }, (err, response) => {
       if (err) {
         t.strictEqual(err.message, 'HTTP/2: "GOAWAY" frame received with code 0')
-        t.strictEqual(err.code, 'UND_ERR_SOCKET')
+        t.strictEqual(err.code, 'UND_ERR_INFO')
       } else {
         t.strictEqual(response.statusCode, 200)
         ;(async function () {
@@ -138,7 +133,7 @@ test('#3753 - Handle GOAWAY Gracefully', async (t) => {
           try {
             body = await response.body.text()
           } catch (err) {
-            t.strictEqual(err.code, 'UND_ERR_SOCKET')
+            t.fail(err)
             return
           }
           t.strictEqual(body, 'hello world')
@@ -146,6 +141,91 @@ test('#3753 - Handle GOAWAY Gracefully', async (t) => {
       }
     })
   }
+
+  await t.completed
+})
+
+test('#5089 - Handle GOAWAY Gracefully', async (t) => {
+  t = tspl(t, { plan: 7 })
+
+  const server = createSecureServer({
+    ...await pem.generate({
+      opts: { keySize: 2048 }
+    }),
+    settings: {
+      maxConcurrentStreams: 2
+    }
+  })
+  let firstSession = null
+  const sessionCounts = new Map()
+
+  server.on('session', (session) => {
+    sessionCounts.set(session, 0)
+
+    if (firstSession == null) {
+      firstSession = session
+    }
+  })
+
+  server.on('stream', (stream) => {
+    const count = sessionCounts.get(stream.session) + 1
+    sessionCounts.set(stream.session, count)
+
+    if (stream.session === firstSession && count === 2) {
+      setTimeout(() => {
+        firstSession.goaway()
+      }, 20)
+    }
+
+    stream.respond({
+      'content-type': 'text/plain',
+      ':status': 200
+    })
+    setTimeout(() => {
+      stream.end('hello world')
+    }, 150)
+  })
+
+  after(() => server.close())
+  await once(server.listen(0), 'listening')
+
+  const client = new Client(`https://localhost:${server.address().port}`, {
+    connect: {
+      rejectUnauthorized: false
+    },
+    maxConcurrentStreams: 2,
+    pipelining: 10,
+    allowH2: true
+  })
+  after(() => client.close())
+
+  client.on('connectionError', () => {
+    t.fail('unexpected connectionError')
+  })
+
+  client.once('disconnect', (url, disconnectClient, err) => {
+    t.ok(url instanceof URL)
+    t.deepStrictEqual(disconnectClient, [client])
+    t.strictEqual(err.message, 'HTTP/2: "GOAWAY" frame received with code 0')
+    t.strictEqual(err.code, 'UND_ERR_INFO')
+  })
+
+  const results = await Promise.all(Array.from({ length: 6 }, () => client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'x-my-header': 'foo'
+    }
+  }).then(async (response) => {
+    return {
+      statusCode: response.statusCode,
+      body: await response.body.text()
+    }
+  })))
+
+  t.deepStrictEqual([...sessionCounts.values()], [2, 4])
+  t.deepStrictEqual(results.map((result) => result.statusCode), Array(6).fill(200))
+  t.deepStrictEqual(results.map((result) => result.body), Array(6).fill('hello world'))
 
   await t.completed
 })

--- a/test/http2-late-data.js
+++ b/test/http2-late-data.js
@@ -23,64 +23,64 @@ const {
   kPingInterval
 } = require('../lib/core/symbols')
 
+class FakeSocket extends EventEmitter {
+  constructor () {
+    super()
+    this.destroyed = false
+  }
+
+  destroy () {
+    this.destroyed = true
+    return this
+  }
+
+  ref () {}
+  unref () {}
+}
+
+class FakeStream extends EventEmitter {
+  setTimeout () {}
+  pause () {}
+  resume () {}
+  close () {}
+  write () { return true }
+  end () {}
+  cork () {}
+  uncork () {}
+}
+
+class FakeSession extends EventEmitter {
+  constructor (stream) {
+    super()
+    this.stream = stream
+    this.closed = false
+    this.destroyed = false
+  }
+
+  request () {
+    return this.stream
+  }
+
+  close () {
+    this.closed = true
+  }
+
+  destroy () {
+    this.destroyed = true
+  }
+
+  ref () {}
+  unref () {}
+  ping (_, cb) {
+    cb(null, 0)
+  }
+}
+
 test('Should ignore late http2 data after request completion', async (t) => {
   t = tspl(t, { plan: 6 })
 
   const http2 = require('node:http2')
   const originalConnect = http2.connect
-
-  class FakeSocket extends EventEmitter {
-    constructor () {
-      super()
-      this.destroyed = false
-    }
-
-    destroy () {
-      this.destroyed = true
-      return this
-    }
-
-    ref () {}
-    unref () {}
-  }
-
-  class FakeStream extends EventEmitter {
-    setTimeout () {}
-    pause () {}
-    resume () {}
-    close () {}
-    write () { return true }
-    end () {}
-    cork () {}
-    uncork () {}
-  }
-
-  class FakeSession extends EventEmitter {
-    constructor (stream) {
-      super()
-      this.stream = stream
-      this.closed = false
-      this.destroyed = false
-    }
-
-    request () {
-      return this.stream
-    }
-
-    close () {
-      this.closed = true
-    }
-
-    destroy () {
-      this.destroyed = true
-    }
-
-    ref () {}
-    unref () {}
-    ping (_, cb) {
-      cb(null, 0)
-    }
-  }
 
   const stream = new FakeStream()
   const session = new FakeSession(stream)
@@ -166,59 +166,6 @@ test('Should remove request-owned http2 stream listeners after completion', asyn
 
   const http2 = require('node:http2')
   const originalConnect = http2.connect
-
-  class FakeSocket extends EventEmitter {
-    constructor () {
-      super()
-      this.destroyed = false
-    }
-
-    destroy () {
-      this.destroyed = true
-      return this
-    }
-
-    ref () {}
-    unref () {}
-  }
-
-  class FakeStream extends EventEmitter {
-    setTimeout () {}
-    pause () {}
-    resume () {}
-    close () {}
-    write () { return true }
-    end () {}
-    cork () {}
-    uncork () {}
-  }
-
-  class FakeSession extends EventEmitter {
-    constructor (stream) {
-      super()
-      this.stream = stream
-      this.closed = false
-      this.destroyed = false
-    }
-
-    request () {
-      return this.stream
-    }
-
-    close () {
-      this.closed = true
-    }
-
-    destroy () {
-      this.destroyed = true
-    }
-
-    ref () {}
-    unref () {}
-    ping (_, cb) {
-      cb(null, 0)
-    }
-  }
 
   const stream = new FakeStream()
   const session = new FakeSession(stream)

--- a/test/http2-late-data.js
+++ b/test/http2-late-data.js
@@ -162,7 +162,7 @@ test('Should ignore late http2 data after request completion', async (t) => {
 })
 
 test('Should remove request-owned http2 stream listeners after completion', async (t) => {
-  t = tspl(t, { plan: 5 })
+  t = tspl(t, { plan: 7 })
 
   const http2 = require('node:http2')
   const originalConnect = http2.connect
@@ -271,12 +271,14 @@ test('Should remove request-owned http2 stream listeners after completion', asyn
   client[kQueue].push(request)
 
   t.ok(context.write(request))
+  t.equal(stream.listenerCount('aborted'), 1)
   t.equal(stream.listenerCount('timeout'), 1)
   t.equal(stream.listenerCount('trailers'), 1)
 
   stream.emit('response', { ':status': 200 })
   stream.emit('end')
 
+  t.equal(stream.listenerCount('aborted'), 0)
   t.equal(stream.listenerCount('timeout'), 0)
   t.equal(stream.listenerCount('trailers'), 0)
 

--- a/test/http2-late-data.js
+++ b/test/http2-late-data.js
@@ -160,3 +160,125 @@ test('Should ignore late http2 data after request completion', async (t) => {
 
   await t.completed
 })
+
+test('Should remove request-owned http2 stream listeners after completion', async (t) => {
+  t = tspl(t, { plan: 5 })
+
+  const http2 = require('node:http2')
+  const originalConnect = http2.connect
+
+  class FakeSocket extends EventEmitter {
+    constructor () {
+      super()
+      this.destroyed = false
+    }
+
+    destroy () {
+      this.destroyed = true
+      return this
+    }
+
+    ref () {}
+    unref () {}
+  }
+
+  class FakeStream extends EventEmitter {
+    setTimeout () {}
+    pause () {}
+    resume () {}
+    close () {}
+    write () { return true }
+    end () {}
+    cork () {}
+    uncork () {}
+  }
+
+  class FakeSession extends EventEmitter {
+    constructor (stream) {
+      super()
+      this.stream = stream
+      this.closed = false
+      this.destroyed = false
+    }
+
+    request () {
+      return this.stream
+    }
+
+    close () {
+      this.closed = true
+    }
+
+    destroy () {
+      this.destroyed = true
+    }
+
+    ref () {}
+    unref () {}
+    ping (_, cb) {
+      cb(null, 0)
+    }
+  }
+
+  const stream = new FakeStream()
+  const session = new FakeSession(stream)
+
+  http2.connect = function connectStub () {
+    return session
+  }
+
+  after(() => {
+    http2.connect = originalConnect
+  })
+
+  const client = {
+    [kUrl]: new URL('https://localhost'),
+    [kSocket]: null,
+    [kMaxConcurrentStreams]: 100,
+    [kHTTP2InitialWindowSize]: null,
+    [kHTTP2ConnectionWindowSize]: null,
+    [kBodyTimeout]: 30_000,
+    [kStrictContentLength]: true,
+    [kQueue]: [],
+    [kRunningIdx]: 0,
+    [kPendingIdx]: 0,
+    [kRunning]: 1,
+    [kPingInterval]: 0,
+    [kOnError] (err) {
+      t.ifError(err)
+    },
+    [kResume] () {},
+    emit () {},
+    destroyed: false
+  }
+
+  const context = connectH2(client, new FakeSocket())
+
+  const request = new Request('https://localhost', {
+    path: '/',
+    method: 'GET',
+    headers: {}
+  }, {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd () {},
+    onResponseError (_controller, err) {
+      t.ifError(err)
+    }
+  })
+
+  client[kQueue].push(request)
+
+  t.ok(context.write(request))
+  t.equal(stream.listenerCount('timeout'), 1)
+  t.equal(stream.listenerCount('trailers'), 1)
+
+  stream.emit('response', { ':status': 200 })
+  stream.emit('end')
+
+  t.equal(stream.listenerCount('timeout'), 0)
+  t.equal(stream.listenerCount('trailers'), 0)
+
+  await t.completed
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved HTTP/2 connection termination and graceful shutdown handling
  * Enhanced request finalization and resource cleanup to prevent memory leaks
  * Better stream lifecycle management and error propagation
  * Improved handling of concurrent streaming requests under constrained conditions

* **Tests**
  * Added comprehensive HTTP/2 regression test coverage for connection lifecycle and request cleanup scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->