### PR TITLE
perf: defer header buffer concatenation in client-h1 parser

### DIFF
--- a/benchmarks/core/parser-header-fragments.mjs
+++ b/benchmarks/core/parser-header-fragments.mjs
@@ -1,0 +1,152 @@
+import assert from 'node:assert'
+import net from 'node:net'
+import process from 'node:process'
+import { once } from 'node:events'
+
+import { bench, group, run } from 'mitata'
+
+import undici from '../../index.js'
+import symbols from '../../lib/core/symbols.js'
+
+const { Client } = undici
+const { kSocket, kParser } = symbols
+
+const headerValueBytes = parseInt(process.env.HEADER_VALUE_BYTES ?? '4096', 10)
+const fragmentBytes = parseInt(process.env.FRAGMENT_BYTES ?? '16', 10)
+const minSamples = parseInt(process.env.MIN_SAMPLES ?? '100', 10)
+const maxSamples = parseInt(process.env.MAX_SAMPLES ?? '200', 10)
+
+function splitBuffer (buffer, size) {
+  const chunks = []
+
+  for (let i = 0; i < buffer.length; i += size) {
+    chunks.push(buffer.subarray(i, i + size))
+  }
+
+  return chunks
+}
+
+function resetParserState (parser) {
+  parser.headers = []
+  parser.headersSize = 0
+  parser.keepAlive = ''
+  parser.contentLength = ''
+  parser.connection = ''
+}
+
+function finalizeHeadersCompat (parser) {
+  if (typeof parser.finalizeHeaders === 'function') {
+    parser.finalizeHeaders()
+  }
+}
+
+function createScenario (fragmented) {
+  const longValue = Buffer.alloc(headerValueBytes, 'a')
+  const headers = [
+    [Buffer.from('connection'), Buffer.from('keep-alive')],
+    [Buffer.from('keep-alive'), Buffer.from('timeout=1')],
+    [Buffer.from('content-length'), Buffer.from('5')],
+    [Buffer.from('x-benchmark-header'), longValue]
+  ]
+
+  return headers.map(([field, value]) => ({
+    field: fragmented ? splitBuffer(field, fragmentBytes) : [field],
+    value: fragmented ? splitBuffer(value, fragmentBytes) : [value]
+  }))
+}
+
+function runScenario (parser, scenario) {
+  resetParserState(parser)
+
+  for (const entry of scenario) {
+    for (const chunk of entry.field) {
+      parser.onHeaderField(chunk)
+    }
+
+    for (const chunk of entry.value) {
+      parser.onHeaderValue(chunk)
+    }
+  }
+
+  finalizeHeadersCompat(parser)
+}
+
+function validateScenario (parser, scenario) {
+  runScenario(parser, scenario)
+
+  assert.strictEqual(parser.headers[0].toString(), 'connection')
+  assert.strictEqual(parser.headers[1].toString(), 'keep-alive')
+  assert.strictEqual(parser.headers[2].toString(), 'keep-alive')
+  assert.strictEqual(parser.headers[3].toString(), 'timeout=1')
+  assert.strictEqual(parser.headers[4].toString(), 'content-length')
+  assert.strictEqual(parser.headers[5].toString(), '5')
+  assert.strictEqual(parser.headers[6].toString(), 'x-benchmark-header')
+  assert.strictEqual(parser.headers[7].length, headerValueBytes)
+  assert.strictEqual(parser.connection, 'keep-alive')
+  assert.strictEqual(parser.keepAlive, 'timeout=1')
+  assert.strictEqual(parser.contentLength, '5')
+
+  resetParserState(parser)
+}
+
+async function createParser () {
+  const server = net.createServer((socket) => {
+    socket.once('data', () => {
+      socket.write('HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: keep-alive\r\n\r\n')
+    })
+  })
+
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  const address = server.address()
+  const client = new Client(`http://127.0.0.1:${address.port}`)
+
+  const { body } = await client.request({
+    path: '/',
+    method: 'GET'
+  })
+  await body.text()
+
+  const parser = client[kSocket][kParser]
+
+  return {
+    client,
+    parser,
+    async close () {
+      await client.close()
+      server.close()
+      await once(server, 'close')
+    }
+  }
+}
+
+const parserContext = await createParser()
+
+try {
+  const contiguous = createScenario(false)
+  const fragmented = createScenario(true)
+
+  validateScenario(parserContext.parser, contiguous)
+  validateScenario(parserContext.parser, fragmented)
+
+  console.log('parser-header-fragments')
+  console.log(`headerValueBytes=${headerValueBytes} fragmentBytes=${fragmentBytes} minSamples=${minSamples} maxSamples=${maxSamples}`)
+
+  group('client-h1 parser callbacks', () => {
+    bench('contiguous headers', () => {
+      runScenario(parserContext.parser, contiguous)
+    })
+
+    bench('fragmented headers', () => {
+      runScenario(parserContext.parser, fragmented)
+    })
+  })
+
+  await run({
+    min_samples: minSamples,
+    max_samples: maxSamples
+  })
+} finally {
+  await parserContext.close()
+}

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -237,6 +237,27 @@ class Parser {
     this.maxResponseSize = client[kMaxResponseSize]
   }
 
+  /**
+   * @param {number} index
+   * @returns {Buffer}
+   */
+  getHeaderBuffer (index) {
+    const header = this.headers[index]
+    if (Array.isArray(header)) {
+      const value = Buffer.concat(header)
+      this.headers[index] = value
+      return value
+    }
+
+    return header
+  }
+
+  finalizeHeaders () {
+    for (let i = 0; i < this.headers.length; i++) {
+      this.getHeaderBuffer(i)
+    }
+  }
+
   setTimeout (delay, type) {
     // If the existing timer and the new timer are of different timer type
     // (fast or native) or have different delay, we need to clear the existing
@@ -429,7 +450,12 @@ class Parser {
     if ((len & 1) === 0) {
       this.headers.push(buf)
     } else {
-      this.headers[len - 1] = Buffer.concat([this.headers[len - 1], buf])
+      const header = this.headers[len - 1]
+      if (Array.isArray(header)) {
+        header.push(buf)
+      } else {
+        this.headers[len - 1] = [header, buf]
+      }
     }
 
     this.trackHeader(buf.length)
@@ -448,10 +474,15 @@ class Parser {
       this.headers.push(buf)
       len += 1
     } else {
-      this.headers[len - 1] = Buffer.concat([this.headers[len - 1], buf])
+      const header = this.headers[len - 1]
+      if (Array.isArray(header)) {
+        header.push(buf)
+      } else {
+        this.headers[len - 1] = [header, buf]
+      }
     }
 
-    const key = this.headers[len - 2]
+    const key = this.getHeaderBuffer(len - 2)
     if (key.length === 10) {
       const headerName = util.bufferToLowerCasedHeaderName(key)
       if (headerName === 'keep-alive') {
@@ -491,6 +522,8 @@ class Parser {
     assert(!socket.destroyed)
     assert(!this.paused)
     assert((headers.length & 1) === 0)
+
+    this.finalizeHeaders()
 
     const request = client[kQueue][client[kRunningIdx]]
     assert(request)
@@ -593,6 +626,7 @@ class Parser {
     }
 
     assert((this.headers.length & 1) === 0)
+    this.finalizeHeaders()
     this.headers = []
     this.headersSize = 0
 
@@ -692,6 +726,8 @@ class Parser {
 
     assert(statusCode >= 100)
     assert((this.headers.length & 1) === 0)
+
+    this.finalizeHeaders()
 
     const request = client[kQueue][client[kRunningIdx]]
     assert(request)

--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -195,3 +195,48 @@ test('refreshes wasm input view after reallocating parser buffer', async (t) => 
   t.strictEqual(largeResponse.statusCode, 200)
   t.strictEqual(largeResponse.body.toString(), largeBody.toString())
 })
+
+test('split special-case headers across multiple parser callbacks', async (t) => {
+  t = tspl(t, { plan: 5 })
+
+  const server = net.createServer(socket => {
+    socket.write('HTTP/1.1 200 OK\r\nConnec')
+    setTimeout(() => {
+      socket.write('tion: keep-')
+      setTimeout(() => {
+        socket.write('alive\r\nKeep')
+        setTimeout(() => {
+          socket.write('-Alive: timeout=')
+          setTimeout(() => {
+            socket.write('1\r\nContent-Len')
+            setTimeout(() => {
+              socket.write('gth: 5\r\nX-Test: hel')
+              setTimeout(() => {
+                socket.write('lo\r\n\r\nhello')
+              }, 20)
+            }, 20)
+          }, 20)
+        }, 20)
+      }, 20)
+    }, 20)
+  })
+  after(() => server.close())
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(() => client.destroy())
+
+    client.request({
+      method: 'GET',
+      path: '/'
+    }, async (err, data) => {
+      t.ifError(err)
+      t.equal(data.headers.connection, 'keep-alive')
+      t.equal(data.headers['keep-alive'], 'timeout=1')
+      t.equal(data.headers['content-length'], '5')
+      t.equal(await data.body.text(), 'hello')
+    })
+  })
+
+  await t.completed
+})


### PR DESCRIPTION
Posting for future reference.

Dropped as practical perf improvement is minimal, and there could be some regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of HTTP headers fragmented across multiple TCP packets, ensuring proper parsing and normalization of special header values such as Connection and Content-Length throughout the connection lifecycle.

* **Performance**
  * Optimized HTTP/1 parser performance by deferring header-value concatenation operations until headers are fully finalized, significantly reducing redundant buffer processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->