### PR TITLE
perf: compare h1 parser tokens without lowercasing

### DIFF
--- a/benchmarks/dispatcher/client-h1-parser-special-headers.mjs
+++ b/benchmarks/dispatcher/client-h1-parser-special-headers.mjs
@@ -1,0 +1,180 @@
+import { bench, group, run } from 'mitata'
+import { bufferToLowerCasedHeaderName } from '../../lib/core/util.js'
+
+function bufferEqualsContentLength (buf) {
+  return buf.length === 14 &&
+    (buf[0] | 32) === 99 &&
+    (buf[1] | 32) === 111 &&
+    (buf[2] | 32) === 110 &&
+    (buf[3] | 32) === 116 &&
+    (buf[4] | 32) === 101 &&
+    (buf[5] | 32) === 110 &&
+    (buf[6] | 32) === 116 &&
+    buf[7] === 45 &&
+    (buf[8] | 32) === 108 &&
+    (buf[9] | 32) === 101 &&
+    (buf[10] | 32) === 110 &&
+    (buf[11] | 32) === 103 &&
+    (buf[12] | 32) === 116 &&
+    (buf[13] | 32) === 104
+}
+
+function bufferEqualsConnection (buf) {
+  return buf.length === 10 &&
+    (buf[0] | 32) === 99 &&
+    (buf[1] | 32) === 111 &&
+    (buf[2] | 32) === 110 &&
+    (buf[3] | 32) === 110 &&
+    (buf[4] | 32) === 101 &&
+    (buf[5] | 32) === 99 &&
+    (buf[6] | 32) === 116 &&
+    (buf[7] | 32) === 105 &&
+    (buf[8] | 32) === 111 &&
+    (buf[9] | 32) === 110
+}
+
+function bufferEqualsKeepAlive (buf) {
+  return buf.length === 10 &&
+    (buf[0] | 32) === 107 &&
+    (buf[1] | 32) === 101 &&
+    (buf[2] | 32) === 101 &&
+    (buf[3] | 32) === 112 &&
+    buf[4] === 45 &&
+    (buf[5] | 32) === 97 &&
+    (buf[6] | 32) === 108 &&
+    (buf[7] | 32) === 105 &&
+    (buf[8] | 32) === 118 &&
+    (buf[9] | 32) === 101
+}
+
+function oldOnHeaderValue (parser, buf) {
+  let len = parser.headers.length
+
+  if ((len & 1) === 1) {
+    parser.headers.push(buf)
+    len += 1
+  } else {
+    parser.headers[len - 1] = Buffer.concat([parser.headers[len - 1], buf])
+  }
+
+  const key = parser.headers[len - 2]
+  if (key.length === 10) {
+    const headerName = bufferToLowerCasedHeaderName(key)
+    if (headerName === 'keep-alive') {
+      parser.keepAlive += buf.toString()
+    } else if (headerName === 'connection') {
+      parser.connectionKeepAlive =
+        parser.headers[len - 1].length === 10 &&
+        bufferToLowerCasedHeaderName(parser.headers[len - 1]) === 'keep-alive'
+    }
+  } else if (key.length === 14 && bufferToLowerCasedHeaderName(key) === 'content-length') {
+    parser.contentLength += buf.toString()
+  }
+}
+
+function newOnHeaderValue (parser, buf) {
+  let len = parser.headers.length
+
+  if ((len & 1) === 1) {
+    parser.headers.push(buf)
+    len += 1
+  } else {
+    parser.headers[len - 1] = Buffer.concat([parser.headers[len - 1], buf])
+  }
+
+  const key = parser.headers[len - 2]
+  if (bufferEqualsKeepAlive(key)) {
+    parser.keepAlive += buf.toString()
+  } else if (bufferEqualsConnection(key)) {
+    parser.connectionKeepAlive = bufferEqualsKeepAlive(parser.headers[len - 1])
+  } else if (bufferEqualsContentLength(key)) {
+    parser.contentLength += buf.toString()
+  }
+}
+
+const completeHeaders = [
+  [Buffer.from('Content-Length'), Buffer.from('12345')],
+  [Buffer.from('Connection'), Buffer.from('keep-alive')],
+  [Buffer.from('Keep-Alive'), Buffer.from('timeout=5')],
+  [Buffer.from('X-Request-ID'), Buffer.from('abc123')]
+]
+
+const fragmentedHeaders = [
+  [Buffer.from('Content-Length'), [Buffer.from('12'), Buffer.from('345')]],
+  [Buffer.from('Connection'), [Buffer.from('keep-'), Buffer.from('alive')]],
+  [Buffer.from('Keep-Alive'), [Buffer.from('timeout='), Buffer.from('5')]],
+  [Buffer.from('X-Request-ID'), [Buffer.from('abc'), Buffer.from('123')]]
+]
+
+function resetParser (parser, key) {
+  parser.headers.length = 0
+  parser.headers.push(key)
+  parser.keepAlive = ''
+  parser.connectionKeepAlive = false
+  parser.contentLength = ''
+}
+
+function createParsers () {
+  return Array.from({ length: completeHeaders.length }, () => ({
+    headers: [],
+    keepAlive: '',
+    connectionKeepAlive: false,
+    contentLength: ''
+  }))
+}
+
+group('client-h1 parser special headers', () => {
+  const oldParsers = createParsers()
+  const newParsers = createParsers()
+
+  bench('old lowercased header name', () => {
+    for (let i = 0; i < completeHeaders.length; ++i) {
+      const [key, value] = completeHeaders[i]
+      const parser = oldParsers[i]
+
+      resetParser(parser, key)
+      oldOnHeaderValue(parser, value)
+    }
+  })
+
+  bench('new buffer equality', () => {
+    for (let i = 0; i < completeHeaders.length; ++i) {
+      const [key, value] = completeHeaders[i]
+      const parser = newParsers[i]
+
+      resetParser(parser, key)
+      newOnHeaderValue(parser, value)
+    }
+  })
+})
+
+group('client-h1 parser fragmented special headers', () => {
+  const oldParsers = createParsers()
+  const newParsers = createParsers()
+
+  bench('old lowercased header name', () => {
+    for (let i = 0; i < fragmentedHeaders.length; ++i) {
+      const [key, values] = fragmentedHeaders[i]
+      const parser = oldParsers[i]
+
+      resetParser(parser, key)
+      for (let j = 0; j < values.length; ++j) {
+        oldOnHeaderValue(parser, values[j])
+      }
+    }
+  })
+
+  bench('new buffer equality', () => {
+    for (let i = 0; i < fragmentedHeaders.length; ++i) {
+      const [key, values] = fragmentedHeaders[i]
+      const parser = newParsers[i]
+
+      resetParser(parser, key)
+      for (let j = 0; j < values.length; ++j) {
+        newOnHeaderValue(parser, values[j])
+      }
+    }
+  })
+})
+
+await run()

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -58,6 +58,52 @@ const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const removeAllListeners = util.removeAllListeners
 
+function bufferEqualsContentLength (buf) {
+  return buf.length === 14 &&
+    (buf[0] | 32) === 99 &&
+    (buf[1] | 32) === 111 &&
+    (buf[2] | 32) === 110 &&
+    (buf[3] | 32) === 116 &&
+    (buf[4] | 32) === 101 &&
+    (buf[5] | 32) === 110 &&
+    (buf[6] | 32) === 116 &&
+    buf[7] === 45 &&
+    (buf[8] | 32) === 108 &&
+    (buf[9] | 32) === 101 &&
+    (buf[10] | 32) === 110 &&
+    (buf[11] | 32) === 103 &&
+    (buf[12] | 32) === 116 &&
+    (buf[13] | 32) === 104
+}
+
+function bufferEqualsConnection (buf) {
+  return buf.length === 10 &&
+    (buf[0] | 32) === 99 &&
+    (buf[1] | 32) === 111 &&
+    (buf[2] | 32) === 110 &&
+    (buf[3] | 32) === 110 &&
+    (buf[4] | 32) === 101 &&
+    (buf[5] | 32) === 99 &&
+    (buf[6] | 32) === 116 &&
+    (buf[7] | 32) === 105 &&
+    (buf[8] | 32) === 111 &&
+    (buf[9] | 32) === 110
+}
+
+function bufferEqualsKeepAlive (buf) {
+  return buf.length === 10 &&
+    (buf[0] | 32) === 107 &&
+    (buf[1] | 32) === 101 &&
+    (buf[2] | 32) === 101 &&
+    (buf[3] | 32) === 112 &&
+    buf[4] === 45 &&
+    (buf[5] | 32) === 97 &&
+    (buf[6] | 32) === 108 &&
+    (buf[7] | 32) === 105 &&
+    (buf[8] | 32) === 118 &&
+    (buf[9] | 32) === 101
+}
+
 let extractBody
 
 function lazyllhttp () {
@@ -452,16 +498,11 @@ class Parser {
     }
 
     const key = this.headers[len - 2]
-    if (key.length === 10) {
-      const headerName = util.bufferToLowerCasedHeaderName(key)
-      if (headerName === 'keep-alive') {
-        this.keepAlive += buf.toString()
-      } else if (headerName === 'connection') {
-        this.connectionKeepAlive =
-          this.headers[len - 1].length === 10 &&
-          util.bufferToLowerCasedHeaderName(this.headers[len - 1]) === 'keep-alive'
-      }
-    } else if (key.length === 14 && util.bufferToLowerCasedHeaderName(key) === 'content-length') {
+    if (bufferEqualsKeepAlive(key)) {
+      this.keepAlive += buf.toString()
+    } else if (bufferEqualsConnection(key)) {
+      this.connectionKeepAlive = bufferEqualsKeepAlive(this.headers[len - 1])
+    } else if (bufferEqualsContentLength(key)) {
       this.contentLength += buf.toString()
     }
 

--- a/test/parser-issues.js
+++ b/test/parser-issues.js
@@ -4,6 +4,7 @@ const { tspl } = require('@matteo.collina/tspl')
 const { test, after } = require('node:test')
 const net = require('node:net')
 const { Client, errors } = require('..')
+const { kSocket, kParser } = require('../lib/core/symbols.js')
 
 test('https://github.com/mcollina/undici/issues/268', async (t) => {
   t = tspl(t, { plan: 2 })
@@ -194,4 +195,84 @@ test('refreshes wasm input view after reallocating parser buffer', async (t) => 
   const largeResponse = await request()
   t.strictEqual(largeResponse.statusCode, 200)
   t.strictEqual(largeResponse.body.toString(), largeBody.toString())
+})
+
+test('split special-case headers across multiple parser callbacks', async (t) => {
+  t = tspl(t, { plan: 5 })
+
+  const server = net.createServer(socket => {
+    socket.write('HTTP/1.1 200 OK\r\nConnec')
+    setTimeout(() => {
+      socket.write('tion: keep-')
+      setTimeout(() => {
+        socket.write('alive\r\nKeep')
+        setTimeout(() => {
+          socket.write('-Alive: timeout=')
+          setTimeout(() => {
+            socket.write('1\r\nContent-Len')
+            setTimeout(() => {
+              socket.write('gth: 5\r\nX-Test: hel')
+              setTimeout(() => {
+                socket.write('lo\r\n\r\nhello')
+              }, 20)
+            }, 20)
+          }, 20)
+        }, 20)
+      }, 20)
+    }, 20)
+  })
+  after(() => server.close())
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    after(() => client.destroy())
+
+    client.request({
+      method: 'GET',
+      path: '/'
+    }, async (err, data) => {
+      t.ifError(err)
+      t.equal(data.headers.connection, 'keep-alive')
+      t.equal(data.headers['keep-alive'], 'timeout=1')
+      t.equal(data.headers['content-length'], '5')
+      t.equal(await data.body.text(), 'hello')
+    })
+  })
+
+  await t.completed
+})
+
+test('split connection keep-alive header updates parser keep-alive state', async (t) => {
+  t = tspl(t, { plan: 2 })
+
+  const server = net.createServer(socket => {
+    socket.once('data', () => {
+      socket.write('HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n')
+    })
+  })
+  after(() => server.close())
+
+  await new Promise(resolve => server.listen(0, resolve))
+
+  const client = new Client(`http://localhost:${server.address().port}`)
+  after(() => client.destroy())
+
+  const { body } = await client.request({
+    method: 'GET',
+    path: '/'
+  })
+  await body.text()
+
+  const parser = client[kSocket][kParser]
+  parser.headers = []
+  parser.headersSize = 0
+  parser.connectionKeepAlive = false
+
+  parser.onHeaderField(Buffer.from('Connec'))
+  parser.onHeaderField(Buffer.from('tion'))
+  parser.onHeaderValue(Buffer.from('keep-'))
+  parser.onHeaderValue(Buffer.from('alive'))
+
+  t.equal(parser.headers[0].toString(), 'Connection')
+  t.equal(parser.connectionKeepAlive, true)
 })


### PR DESCRIPTION
For future reference. The performance benefits are minimal

```console
benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• client-h1 parser special headers
------------------------------------------- -------------------------------
old lowercased header name   397.63 ns/iter 401.54 ns █                    
                    (389.31 ns … 480.77 ns) 467.74 ns ██                   
                    (494.89  b … 728.32  b) 664.51  b ██▅▆▆▃▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁

new buffer equality          291.14 ns/iter 290.18 ns █▇                   
                    (283.34 ns … 380.52 ns) 356.90 ns ██                   
                    (491.89  b … 762.07  b) 663.90  b ██▇▃▂▂▃▂▂▁▁▁▁▁▂▁▁▁▁▁▁

• client-h1 parser fragmented special headers
------------------------------------------- -------------------------------
old lowercased header name   955.08 ns/iter 967.26 ns  ▆▄█                 
                      (933.95 ns … 1.04 µs)   1.02 µs ▃███▄   ▃▃           
                    (  1.37 kb …   1.38 kb)   1.38 kb ██████▇▇██▂▇▂▂▃▂▂▃▁▁▂

new buffer equality          747.58 ns/iter 744.33 ns █                    
                      (718.42 ns … 1.18 µs) 955.43 ns █                    
                    (  1.27 kb …   1.48 kb)   1.38 kb █▆▃▃▃▂▁▁▁▁▁▁▂▂▁▁▁▁▁▁▁
```