### PR TITLE
changes by openai gpt 5.5

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -217,6 +217,7 @@ class Parser {
      */
     this.socket = socket
     this.timeout = null
+    this.timeoutWeakRef = new WeakRef(this)
     this.timeoutValue = null
     this.timeoutType = null
     this.statusCode = 0
@@ -254,9 +255,9 @@ class Parser {
 
       if (delay) {
         if (type & USE_FAST_TIMER) {
-          this.timeout = timers.setFastTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = timers.setFastTimeout(onParserTimeout, delay, this.timeoutWeakRef)
         } else {
-          this.timeout = setTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = setTimeout(onParserTimeout, delay, this.timeoutWeakRef)
           this.timeout?.unref()
         }
       }

--- a/test/jest/parser-timeout-weakref.test.js
+++ b/test/jest/parser-timeout-weakref.test.js
@@ -1,0 +1,62 @@
+'use strict'
+/* global jest, describe, it, beforeEach, afterEach, expect */
+
+const EventEmitter = require('node:events')
+const connectH1 = require('../../lib/dispatcher/client-h1')
+const {
+  kMaxHeadersSize,
+  kMaxResponseSize,
+  kParser,
+  kQueue,
+  kRunningIdx
+} = require('../../lib/core/symbols')
+
+class DummySocket extends EventEmitter {
+  constructor () {
+    super()
+    this.destroyed = false
+    this.errored = null
+  }
+
+  read () {
+    return null
+  }
+}
+
+const dummyClient = {
+  [kMaxHeadersSize]: 1024,
+  [kMaxResponseSize]: 1024,
+  [kQueue]: [],
+  [kRunningIdx]: 0
+}
+
+describe('Parser#setTimeout WeakRef allocation', () => {
+  beforeEach(() => jest.useFakeTimers('modern'))
+  afterEach(() => jest.useRealTimers())
+
+  it('reuses the parser WeakRef when replacing timers', async () => {
+    const OriginalWeakRef = global.WeakRef
+    let weakRefCount = 0
+
+    global.WeakRef = class CountingWeakRef extends OriginalWeakRef {
+      constructor (target) {
+        weakRefCount++
+        super(target)
+      }
+    }
+
+    try {
+      const socket = new DummySocket()
+      await connectH1(dummyClient, socket)
+      const parser = socket[kParser]
+
+      parser.setTimeout(200, 0)
+      parser.setTimeout(300, 0)
+      parser.setTimeout(400, 1)
+
+      expect(weakRefCount).toBe(1)
+    } finally {
+      global.WeakRef = OriginalWeakRef
+    }
+  })
+})


### PR DESCRIPTION
Instructions

> Reuse parser WeakRef for timers client-h1.js · L239 allocates new WeakRef(this) whenever the timeout delay/type changes. That happens during common transitions like headers timeout to body timeout. Storing one this.timeoutWeakRef per parser would remove small but steady allocation churn.