### PR TITLE
commit created by local gemma4 26B

### DIFF
--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -235,6 +235,7 @@ class Parser {
     this.contentLength = ''
     this.connectionKeepAlive = false
     this.maxResponseSize = client[kMaxResponseSize]
+    this.timeoutWeakRef = new WeakRef(this)
   }
 
   setTimeout (delay, type) {
@@ -254,9 +255,9 @@ class Parser {
 
       if (delay) {
         if (type & USE_FAST_TIMER) {
-          this.timeout = timers.setFastTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = timers.setFastTimeout(onParserTimeout, delay, this.timeoutWeakRef)
         } else {
-          this.timeout = setTimeout(onParserTimeout, delay, new WeakRef(this))
+          this.timeout = setTimeout(onParserTimeout, delay, this.timeoutWeakRef)
           this.timeout?.unref()
         }
       }
@@ -387,7 +388,7 @@ class Parser {
     this.timeout = null
     this.timeoutValue = null
     this.timeoutType = null
-
+    this.timeoutWeakRef = undefined
     this.paused = false
   }
 


### PR DESCRIPTION
Instructions

> Reuse parser WeakRef for timers client-h1.js · L239 allocates new WeakRef(this) whenever the timeout delay/type changes. That happens during common transitions like headers timeout to body timeout. Storing one this.timeoutWeakRef per parser would remove small but steady allocation churn.