### PR TITLE
perf(client): fast path H1 GET header serialization

### DIFF
--- a/benchmarks/core/h1-request-header-serialization.mjs
+++ b/benchmarks/core/h1-request-header-serialization.mjs
@@ -1,0 +1,92 @@
+import { bench, group, run } from 'mitata'
+
+const client = {
+  hostHeader: 'host: localhost:3000\r\n',
+  pipelining: 1
+}
+
+const socket = {
+  reset: false
+}
+
+const headers = {
+  none: [],
+  one: ['accept', '*/*'],
+  two: ['accept', '*/*', 'user-agent', 'undici'],
+  four: [
+    'accept', '*/*',
+    'user-agent', 'undici',
+    'accept-language', '*',
+    'cache-control', 'no-cache'
+  ],
+  multi: ['accept', ['text/plain', 'application/json']]
+}
+
+let sink = ''
+let index = 0
+const paths = ['/', '/a', '/abc', '/abcdef']
+
+function buildGenericHeader (client, socket, method, path, host, upgrade, headers) {
+  let header = `${method} ${path} HTTP/1.1\r\n`
+
+  if (typeof host === 'string') {
+    header += `host: ${host}\r\n`
+  } else {
+    header += client.hostHeader
+  }
+
+  if (upgrade) {
+    header += `connection: upgrade\r\nupgrade: ${upgrade}\r\n`
+  } else if (client.pipelining && !socket.reset) {
+    header += 'connection: keep-alive\r\n'
+  } else {
+    header += 'connection: close\r\n'
+  }
+
+  for (let n = 0; n < headers.length; n += 2) {
+    const key = headers[n + 0]
+    const val = headers[n + 1]
+
+    if (Array.isArray(val)) {
+      for (let i = 0; i < val.length; i++) {
+        header += `${key}: ${val[i]}\r\n`
+      }
+    } else {
+      header += `${key}: ${val}\r\n`
+    }
+  }
+
+  return header
+}
+
+function buildFastHeader (client, socket, method, path, host, upgrade, headers, isNoBody) {
+  if (method === 'GET' && upgrade == null && isNoBody && headers.length === 0) {
+    const hostHeader = typeof host === 'string'
+      ? `host: ${host}\r\n`
+      : client.hostHeader
+
+    return client.pipelining && !socket.reset
+      ? `GET ${path} HTTP/1.1\r\n${hostHeader}connection: keep-alive\r\n`
+      : `GET ${path} HTTP/1.1\r\n${hostHeader}connection: close\r\n`
+  }
+
+  return buildGenericHeader(client, socket, method, path, host, upgrade, headers)
+}
+
+for (const [name, headerList] of Object.entries(headers)) {
+  group(name, () => {
+    bench('generic', () => {
+      sink = buildGenericHeader(client, socket, 'GET', paths[index++ & 3], null, null, headerList)
+    })
+
+    bench('fast', () => {
+      sink = buildFastHeader(client, socket, 'GET', paths[index++ & 3], null, null, headerList, true)
+    })
+  })
+}
+
+await run()
+
+if (sink.length === 0) {
+  throw new Error('unreachable')
+}

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -1131,33 +1131,45 @@ function writeH1 (client, request) {
     socket.setTypeOfService(request.typeOfService)
   }
 
-  let header = `${method} ${path} HTTP/1.1\r\n`
+  let header
 
-  if (typeof host === 'string') {
-    header += `host: ${host}\r\n`
+  if (method === 'GET' && upgrade == null && (!body || bodyLength === 0) && headers.length === 0) {
+    const hostHeader = typeof host === 'string'
+      ? `host: ${host}\r\n`
+      : client[kHostHeader]
+
+    header = client[kPipelining] && !socket[kReset]
+      ? `GET ${path} HTTP/1.1\r\n${hostHeader}connection: keep-alive\r\n`
+      : `GET ${path} HTTP/1.1\r\n${hostHeader}connection: close\r\n`
   } else {
-    header += client[kHostHeader]
-  }
+    header = `${method} ${path} HTTP/1.1\r\n`
 
-  if (upgrade) {
-    header += `connection: upgrade\r\nupgrade: ${upgrade}\r\n`
-  } else if (client[kPipelining] && !socket[kReset]) {
-    header += 'connection: keep-alive\r\n'
-  } else {
-    header += 'connection: close\r\n'
-  }
+    if (typeof host === 'string') {
+      header += `host: ${host}\r\n`
+    } else {
+      header += client[kHostHeader]
+    }
 
-  if (Array.isArray(headers)) {
-    for (let n = 0; n < headers.length; n += 2) {
-      const key = headers[n + 0]
-      const val = headers[n + 1]
+    if (upgrade) {
+      header += `connection: upgrade\r\nupgrade: ${upgrade}\r\n`
+    } else if (client[kPipelining] && !socket[kReset]) {
+      header += 'connection: keep-alive\r\n'
+    } else {
+      header += 'connection: close\r\n'
+    }
 
-      if (Array.isArray(val)) {
-        for (let i = 0; i < val.length; i++) {
-          header += `${key}: ${val[i]}\r\n`
+    if (Array.isArray(headers)) {
+      for (let n = 0; n < headers.length; n += 2) {
+        const key = headers[n + 0]
+        const val = headers[n + 1]
+
+        if (Array.isArray(val)) {
+          for (let i = 0; i < val.length; i++) {
+            header += `${key}: ${val[i]}\r\n`
+          }
+        } else {
+          header += `${key}: ${val}\r\n`
         }
-      } else {
-        header += `${key}: ${val}\r\n`
       }
     }
   }


### PR DESCRIPTION
Posting for reference. The change is not worth as per benchmarks

```console
benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• none
------------------------------------------- -------------------------------
generic                       22.72 ns/iter  22.31 ns █                    
                      (21.09 ns … 72.31 ns)  41.39 ns █▃                   
                    ( 56.90  b … 225.16  b) 122.22  b ██▄▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁

fast                          21.95 ns/iter  21.48 ns █                    
                      (20.91 ns … 62.91 ns)  38.94 ns █                    
                    ( 15.10  b … 202.12  b) 122.13  b █▅▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

• one
------------------------------------------- -------------------------------
generic                       53.50 ns/iter  52.93 ns █                    
                     (51.98 ns … 105.29 ns)  72.21 ns █▃                   
                    ( 77.81  b … 386.11  b) 242.31  b ██▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

fast                          58.71 ns/iter  58.42 ns █                    
                     (56.45 ns … 134.66 ns)  82.18 ns █▂                   
                    ( 37.29  b … 388.12  b) 248.24  b ██▅▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁

• two
------------------------------------------- -------------------------------
generic                       79.38 ns/iter  79.24 ns █                    
                     (76.46 ns … 120.56 ns) 104.18 ns █▄                   
                    (205.93  b … 522.11  b) 370.23  b ██▆▄▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁

fast                          86.55 ns/iter  86.44 ns █                    
                     (80.71 ns … 228.02 ns) 125.71 ns █▅                   
                    (141.06  b … 506.13  b) 376.15  b ███▅▄▂▂▁▁▁▁▂▁▁▁▁▂▁▁▁▁

• four
------------------------------------------- -------------------------------
generic                      119.27 ns/iter 118.49 ns █▄                   
                    (115.28 ns … 169.30 ns) 152.44 ns ██                   
                    (409.25  b … 796.06  b) 626.27  b ██▇▃▃▃▂▂▁▁▁▁▁▁▁▁▁▂▁▁▁

fast                         122.48 ns/iter 121.22 ns ▆█                   
                    (119.45 ns … 188.68 ns) 153.95 ns ██                   
                    (385.15  b … 794.13  b) 632.15  b ██▄▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁

• multi
------------------------------------------- -------------------------------
generic                       74.10 ns/iter  73.27 ns █                    
                     (72.11 ns … 112.26 ns) 103.82 ns █                    
                    (197.79  b … 530.11  b) 362.35  b ██▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

fast                          76.14 ns/iter  75.38 ns █                    
                     (74.25 ns … 118.35 ns) 105.97 ns █                    
                    (133.03  b … 520.60  b) 362.35  b ██▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized HTTP/1.1 request header construction for improved performance, particularly for common GET request scenarios with streamlined header serialization paths.

* **Tests**
  * Added benchmark suite for measuring HTTP/1.1 request header serialization performance across various request configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->