### PR TITLE
perf(http2): skip timeout listener when body timeout is disabled

### DIFF
--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -539,6 +539,7 @@ function shouldSendContentLength (method) {
 
 function writeH2 (client, request) {
   const requestTimeout = request.bodyTimeout ?? client[kBodyTimeout]
+  const hasRequestTimeout = requestTimeout !== 0
   const session = client[kHTTP2Session]
   const { method, path, host, upgrade, expectContinue, signal, protocol, headers: reqHeaders } = request
   let { body } = request
@@ -669,7 +670,9 @@ function writeH2 (client, request) {
         stream.off('response', onUpgradeResponse)
         stream.off('error', onUpgradeStreamError)
         stream.off('end', onUpgradeStreamEnd)
-        stream.off('timeout', onUpgradeStreamTimeout)
+        if (hasRequestTimeout) {
+          stream.off('timeout', onUpgradeStreamTimeout)
+        }
         stream.off('error', noop)
       }
 
@@ -730,13 +733,17 @@ function writeH2 (client, request) {
       stream.once('response', onUpgradeResponse)
       stream.on('error', onUpgradeStreamError)
       stream.once('end', onUpgradeStreamEnd)
-      stream.on('timeout', onUpgradeStreamTimeout)
+      if (hasRequestTimeout) {
+        stream.on('timeout', onUpgradeStreamTimeout)
+      }
       stream[kHTTP2Session] = session
       stream[kRequestStreamOnCloseError] = failUpgradeStream
       stream.once('close', onUpgradeStreamClose)
 
       ++session[kOpenStreams]
-      stream.setTimeout(requestTimeout)
+      if (hasRequestTimeout) {
+        stream.setTimeout(requestTimeout)
+      }
     }
 
     if (upgrade === 'websocket') {
@@ -887,7 +894,9 @@ function writeH2 (client, request) {
 
   // Increment counter as we have new streams open
   ++session[kOpenStreams]
-  stream.setTimeout(requestTimeout)
+  if (hasRequestTimeout) {
+    stream.setTimeout(requestTimeout)
+  }
 
   // Track whether we received a response (headers)
   let responseReceived = false
@@ -909,7 +918,9 @@ function writeH2 (client, request) {
     stream.off('error', onError)
     stream.off('frameError', onFrameError)
     stream.off('aborted', onAborted)
-    stream.off('timeout', onTimeout)
+    if (hasRequestTimeout) {
+      stream.off('timeout', onTimeout)
+    }
     stream.off('trailers', onTrailers)
     stream.off('data', onData)
   }
@@ -1018,7 +1029,9 @@ function writeH2 (client, request) {
   stream.once('error', onError)
   stream.once('frameError', onFrameError)
   stream.on('aborted', onAborted)
-  stream.on('timeout', onTimeout)
+  if (hasRequestTimeout) {
+    stream.on('timeout', onTimeout)
+  }
   stream.once('trailers', onTrailers)
 
   if (!expectContinue) {

--- a/test/http2-late-data.js
+++ b/test/http2-late-data.js
@@ -39,7 +39,15 @@ class FakeSocket extends EventEmitter {
 }
 
 class FakeStream extends EventEmitter {
-  setTimeout () {}
+  constructor () {
+    super()
+    this.setTimeoutCalls = 0
+  }
+
+  setTimeout () {
+    this.setTimeoutCalls++
+  }
+
   pause () {}
   resume () {}
   close () {}
@@ -226,6 +234,77 @@ test('Should remove request-owned http2 stream listeners after completion', asyn
   stream.emit('end')
 
   t.equal(stream.listenerCount('aborted'), 0)
+  t.equal(stream.listenerCount('timeout'), 0)
+  t.equal(stream.listenerCount('trailers'), 0)
+
+  await t.completed
+})
+
+test('Should not attach http2 timeout listener when body timeout is disabled', async (t) => {
+  t = tspl(t, { plan: 7 })
+
+  const http2 = require('node:http2')
+  const originalConnect = http2.connect
+
+  const stream = new FakeStream()
+  const session = new FakeSession(stream)
+
+  http2.connect = function connectStub () {
+    return session
+  }
+
+  after(() => {
+    http2.connect = originalConnect
+  })
+
+  const client = {
+    [kUrl]: new URL('https://localhost'),
+    [kSocket]: null,
+    [kMaxConcurrentStreams]: 100,
+    [kHTTP2InitialWindowSize]: null,
+    [kHTTP2ConnectionWindowSize]: null,
+    [kBodyTimeout]: 0,
+    [kStrictContentLength]: true,
+    [kQueue]: [],
+    [kRunningIdx]: 0,
+    [kPendingIdx]: 0,
+    [kRunning]: 1,
+    [kPingInterval]: 0,
+    [kOnError] (err) {
+      t.ifError(err)
+    },
+    [kResume] () {},
+    emit () {},
+    destroyed: false
+  }
+
+  const context = connectH2(client, new FakeSocket())
+
+  const request = new Request('https://localhost', {
+    path: '/',
+    method: 'GET',
+    headers: {}
+  }, {
+    onRequestStart () {},
+    onResponseStart () {},
+    onResponseData () {},
+    onResponseEnd () {},
+    onResponseError (_controller, err) {
+      t.ifError(err)
+    }
+  })
+
+  client[kQueue].push(request)
+
+  t.ok(context.write(request))
+  t.equal(stream.setTimeoutCalls, 0)
+  t.equal(stream.listenerCount('timeout'), 0)
+  t.equal(stream.listenerCount('aborted'), 1)
+  t.equal(stream.listenerCount('trailers'), 1)
+
+  stream.emit('response', { ':status': 200 })
+  stream.emit('end')
+
   t.equal(stream.listenerCount('timeout'), 0)
   t.equal(stream.listenerCount('trailers'), 0)
 


### PR DESCRIPTION
<!--
Before submitting a Pull Request, please read our contribution guidelines, which
can be found at CONTRIBUTING.md in the repository root.

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests and linting pass.

You will also need to ensure that your contribution complies with the
Developer's Certificate of Origin, outlined in CONTRIBUTING.md
-->

## This relates to...

HTTP/2 client per-stream listener lifecycle overhead.

## Rationale

HTTP/2 streams were always attaching a timeout listener and calling `setTimeout()`, even when `bodyTimeout` was explicitly disabled with `0`.
Skipping that lifecycle work in the disabled-timeout path reduces per-stream overhead without changing default timeout behavior.

## Changes

- Skip HTTP/2 stream `timeout` listener attachment when body timeout is disabled.
- Skip `stream.setTimeout()` when body timeout is disabled.
- Apply the same disabled-timeout path to regular request streams and upgrade/CONNECT streams.

### Features

N/A

### Bug Fixes

N/A

### Breaking Changes and Deprecations

N/A

## Status

<!-- KEY: S = Skipped, x = complete -->


- [ ] I have read and agreed to the [Developer's Certificate of Origin][cert]
- [ ] Tested
- [ ] Benchmarked (**optional**)
- [ ] Documented
- [ ] Review ready
- [ ] In review
- [ ] Merge ready

[cert]: https://github.com/nodejs/undici/blob/main/CONTRIBUTING.md#developers-certificate-of-origin

Assisted-by: openai:gpt-5.5