### PR TITLE
perf(h2): avoid unnecessary body checks in scheduling

### DIFF
--- a/benchmarks/core/h2-busy-body-check.mjs
+++ b/benchmarks/core/h2-busy-body-check.mjs
@@ -1,0 +1,92 @@
+import { PassThrough } from 'node:stream'
+import { bench, do_not_optimize as doNotOptimize, group, run } from 'mitata'
+import {
+  bodyLength,
+  isAsyncIterable,
+  isFormDataLike,
+  isStream
+} from '../../lib/core/util.js'
+
+const noBody = null
+const buffer = Buffer.alloc(1024)
+const blob = new Blob([buffer])
+const stream = new PassThrough()
+const asyncIterable = {
+  async * [Symbol.asyncIterator] () {
+    yield buffer
+  }
+}
+const formDataLike = {
+  append () {},
+  delete () {},
+  get () {},
+  getAll () {},
+  has () {},
+  set () {},
+  [Symbol.toStringTag]: 'FormData'
+}
+
+function previousBusyBodyCheck (body) {
+  return bodyLength(body) !== 0 &&
+    (isStream(body) || isAsyncIterable(body) || isFormDataLike(body))
+}
+
+function currentBusyBodyCheck (body) {
+  return body != null &&
+    (isStream(body) || isAsyncIterable(body) || isFormDataLike(body)) &&
+    bodyLength(body) !== 0
+}
+
+group('h2 busy body check - previous', () => {
+  bench('GET/no body', () => {
+    doNotOptimize(previousBusyBodyCheck(noBody))
+  })
+
+  bench('buffer', () => {
+    doNotOptimize(previousBusyBodyCheck(buffer))
+  })
+
+  bench('blob', () => {
+    doNotOptimize(previousBusyBodyCheck(blob))
+  })
+
+  bench('stream', () => {
+    doNotOptimize(previousBusyBodyCheck(stream))
+  })
+
+  bench('async iterable', () => {
+    doNotOptimize(previousBusyBodyCheck(asyncIterable))
+  })
+
+  bench('form data like', () => {
+    doNotOptimize(previousBusyBodyCheck(formDataLike))
+  })
+})
+
+group('h2 busy body check - current', () => {
+  bench('GET/no body', () => {
+    doNotOptimize(currentBusyBodyCheck(noBody))
+  })
+
+  bench('buffer', () => {
+    doNotOptimize(currentBusyBodyCheck(buffer))
+  })
+
+  bench('blob', () => {
+    doNotOptimize(currentBusyBodyCheck(blob))
+  })
+
+  bench('stream', () => {
+    doNotOptimize(currentBusyBodyCheck(stream))
+  })
+
+  bench('async iterable', () => {
+    doNotOptimize(currentBusyBodyCheck(asyncIterable))
+  })
+
+  bench('form data like', () => {
+    doNotOptimize(currentBusyBodyCheck(formDataLike))
+  })
+})
+
+await run()

--- a/lib/dispatcher/client-h2.js
+++ b/lib/dispatcher/client-h2.js
@@ -263,8 +263,9 @@ function connectH2 (client, socket) {
           // Request with stream or iterator body cannot be retried.
           // Ensure that no other requests are inflight and
           // could cause failure.
-          if (util.bodyLength(request.body) !== 0 &&
-            (util.isStream(request.body) || util.isAsyncIterable(request.body) || util.isFormDataLike(request.body))) return true
+          if (request.body != null &&
+            (util.isStream(request.body) || util.isAsyncIterable(request.body) || util.isFormDataLike(request.body)) &&
+            util.bodyLength(request.body) !== 0) return true
         } else {
           return (request.upgrade === 'websocket' || request.method === 'CONNECT') && session[kRemoteSettings] === false
         }


### PR DESCRIPTION
Benchmarks

```console
benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• h2 busy body check - previous
------------------------------------------- -------------------------------
GET/no body                  402.29 ps/iter 396.73 ps        █             
                     (376.22 ps … 16.90 ns) 437.26 ps        █             
                    (  0.10  b … 155.64  b)   0.10  b ▁▁▁▂▁▁▁█▁▁▃▁▁▂▁▁▁▁▁▁▁

buffer                        18.84 ns/iter  18.68 ns  █                   
                      (18.56 ns … 50.07 ns)  21.74 ns ▂█                   
                    (  0.10  b …  80.11  b)   0.21  b ██▁▁▂▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

blob                          12.67 ns/iter  12.55 ns █                    
                      (12.51 ns … 51.74 ns)  14.58 ns █                    
                    (  0.10  b …  78.11  b)   0.18  b █▂▁▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁

stream                         3.29 ns/iter   3.15 ns  ▂█                  
                      (3.12 ns … 611.67 ns)   3.45 ns  ██                  
                    (  0.10  b …  78.61  b)   0.11  b ▁██▆▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

async iterable                22.98 ns/iter  22.79 ns █                    
                      (22.74 ns … 58.56 ns)  27.08 ns █                    
                    (  0.10  b …  96.11  b)   0.26  b █▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

form data like                26.38 ns/iter  26.14 ns █                    
                      (26.05 ns … 79.65 ns)  30.05 ns █                    
                    (  0.10  b … 151.41  b)   0.29  b █▅▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

• h2 busy body check - current
------------------------------------------- -------------------------------
GET/no body                  322.43 ps/iter 325.44 ps         █            
                     (294.92 ps … 11.46 ns) 345.95 ps         █   ▆        
                    (  0.10  b …  32.11  b)   0.10  b ▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁▂▁▁▁▁

buffer                         1.49 ns/iter   1.46 ns   █                  
                       (1.43 ns … 27.97 ns)   1.60 ns   █▅▇                
                    (  0.10  b …  48.10  b)   0.11  b ▁▃███▃▂▁▂▂▂▁▁▁▁▁▁▁▁▁▁

blob                           1.49 ns/iter   1.46 ns   █                  
                       (1.43 ns … 24.96 ns)   1.60 ns   █▄                 
                    (  0.10  b …  47.10  b)   0.11  b ▁▃███▂▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁

stream                         4.84 ns/iter   4.69 ns █                    
                       (4.61 ns … 40.41 ns)   9.17 ns █                    
                    (  0.10  b …  48.10  b)   0.13  b █▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

async iterable                33.58 ns/iter  33.47 ns █                    
                      (32.04 ns … 97.68 ns)  46.43 ns █ █                  
                    (  0.10  b …  88.10  b)   0.30  b ███▄▃▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁

form data like                35.63 ns/iter  34.85 ns  █▄                  
                       (32.54 ns … 1.30 µs)  57.50 ns  ██                  
                    (  0.10  b … 104.10  b)   0.31  b ████▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁
```