### PR TITLE
perf(client-h1): defer status text decoding

### DIFF
--- a/benchmarks/core/status-text.mjs
+++ b/benchmarks/core/status-text.mjs
@@ -1,0 +1,174 @@
+import { bench, do_not_optimize as doNotOptimize, group, run } from 'mitata'
+
+const EMPTY_BUF = Buffer.alloc(0)
+const STATUS_TEXT = {
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  204: 'No Content',
+  206: 'Partial Content',
+  301: 'Moved Permanently',
+  302: 'Found',
+  304: 'Not Modified',
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout'
+}
+const STATUS_TEXT_BUF = Object.create(null)
+
+for (const statusCode of Object.keys(STATUS_TEXT)) {
+  STATUS_TEXT_BUF[statusCode] = Buffer.from(STATUS_TEXT[statusCode])
+}
+
+const common = [
+  { statusCode: 200, chunks: [Buffer.from('OK')] },
+  { statusCode: 204, chunks: [Buffer.from('No Content')] },
+  { statusCode: 304, chunks: [Buffer.from('Not Modified')] },
+  { statusCode: 404, chunks: [Buffer.from('Not Found')] },
+  { statusCode: 500, chunks: [Buffer.from('Internal Server Error')] }
+]
+const custom = [
+  { statusCode: 200, chunks: [Buffer.from('Custom Status Text')] },
+  { statusCode: 418, chunks: [Buffer.from('I am a Teapot')] },
+  { statusCode: 599, chunks: [Buffer.from('Network Connect Timeout Error')] }
+]
+const split = [
+  { statusCode: 200, chunks: [Buffer.from('O'), Buffer.from('K')] },
+  { statusCode: 204, chunks: [Buffer.from('No '), Buffer.from('Content')] },
+  { statusCode: 404, chunks: [Buffer.from('Not'), Buffer.from(' Found')] }
+]
+const mixed = [
+  ...common,
+  ...common,
+  ...common,
+  ...common,
+  ...custom,
+  ...split
+]
+
+function eagerStatusText (chunks) {
+  let statusText = ''
+
+  for (let i = 0; i < chunks.length; i++) {
+    statusText = chunks[i].toString()
+  }
+
+  return statusText
+}
+
+function captureStatusText (chunks) {
+  let statusText = EMPTY_BUF
+
+  for (let i = 0; i < chunks.length; i++) {
+    const buf = chunks[i]
+
+    if (statusText === EMPTY_BUF) {
+      statusText = buf
+    } else if (Array.isArray(statusText)) {
+      statusText.push(buf)
+    } else {
+      statusText = [statusText, buf]
+    }
+  }
+
+  return statusText
+}
+
+function isStatusText (buf, statusCode) {
+  const expected = STATUS_TEXT_BUF[statusCode]
+
+  if (expected == null) {
+    return false
+  }
+
+  if (Array.isArray(buf)) {
+    let offset = 0
+
+    for (const chunk of buf) {
+      for (let i = 0; i < chunk.length; i++) {
+        if (chunk[i] !== expected[offset++]) {
+          return false
+        }
+      }
+    }
+
+    return offset === expected.length
+  }
+
+  return buf.equals(expected)
+}
+
+function deferredStatusText (statusCode, chunks) {
+  const statusText = captureStatusText(chunks)
+
+  if (statusText === EMPTY_BUF) {
+    return ''
+  }
+
+  if (isStatusText(statusText, statusCode)) {
+    return STATUS_TEXT[statusCode]
+  }
+
+  return Array.isArray(statusText)
+    ? Buffer.concat(statusText).toString()
+    : statusText.toString()
+}
+
+function runCases (cases, fn) {
+  for (let i = 0; i < cases.length; i++) {
+    const { statusCode, chunks } = cases[i]
+    doNotOptimize(fn(statusCode, chunks))
+  }
+}
+
+group('status text common reason phrases', () => {
+  bench('eager decode', () => {
+    runCases(common, (_statusCode, chunks) => eagerStatusText(chunks))
+  })
+
+  bench('deferred map', () => {
+    runCases(common, deferredStatusText)
+  })
+})
+
+group('status text custom reason phrases', () => {
+  bench('eager decode', () => {
+    runCases(custom, (_statusCode, chunks) => eagerStatusText(chunks))
+  })
+
+  bench('deferred fallback decode', () => {
+    runCases(custom, deferredStatusText)
+  })
+})
+
+group('status text split reason phrases', () => {
+  bench('eager decode', () => {
+    runCases(split, (_statusCode, chunks) => eagerStatusText(chunks))
+  })
+
+  bench('deferred map', () => {
+    runCases(split, deferredStatusText)
+  })
+})
+
+group('status text mixed responses', () => {
+  bench('eager decode', () => {
+    runCases(mixed, (_statusCode, chunks) => eagerStatusText(chunks))
+  })
+
+  bench('deferred map/fallback', () => {
+    runCases(mixed, deferredStatusText)
+  })
+})
+
+await run()

--- a/lib/dispatcher/client-h1.js
+++ b/lib/dispatcher/client-h1.js
@@ -57,8 +57,74 @@ const constants = require('../llhttp/constants.js')
 const EMPTY_BUF = Buffer.alloc(0)
 const FastBuffer = Buffer[Symbol.species]
 const removeAllListeners = util.removeAllListeners
+const STATUS_TEXT = {
+  200: 'OK',
+  201: 'Created',
+  202: 'Accepted',
+  204: 'No Content',
+  206: 'Partial Content',
+  301: 'Moved Permanently',
+  302: 'Found',
+  304: 'Not Modified',
+  400: 'Bad Request',
+  401: 'Unauthorized',
+  403: 'Forbidden',
+  404: 'Not Found',
+  405: 'Method Not Allowed',
+  408: 'Request Timeout',
+  409: 'Conflict',
+  410: 'Gone',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout'
+}
+const STATUS_TEXT_BUF = Object.create(null)
+
+for (const statusCode of Object.keys(STATUS_TEXT)) {
+  STATUS_TEXT_BUF[statusCode] = Buffer.from(STATUS_TEXT[statusCode])
+}
 
 let extractBody
+
+function isStatusText (buf, statusCode) {
+  const expected = STATUS_TEXT_BUF[statusCode]
+
+  if (expected == null) {
+    return false
+  }
+
+  if (Array.isArray(buf)) {
+    let offset = 0
+
+    for (const chunk of buf) {
+      for (let i = 0; i < chunk.length; i++) {
+        if (chunk[i] !== expected[offset++]) {
+          return false
+        }
+      }
+    }
+
+    return offset === expected.length
+  }
+
+  return buf.equals(expected)
+}
+
+function parseStatusText (statusCode, statusText) {
+  if (statusText === EMPTY_BUF) {
+    return ''
+  }
+
+  if (isStatusText(statusText, statusCode)) {
+    return STATUS_TEXT[statusCode]
+  }
+
+  return Array.isArray(statusText)
+    ? Buffer.concat(statusText).toString()
+    : statusText.toString()
+}
 
 function lazyllhttp () {
   const llhttpWasmData = process.env.JEST_WORKER_ID ? require('../llhttp/llhttp-wasm.js') : undefined
@@ -221,7 +287,7 @@ class Parser {
     this.timeoutValue = null
     this.timeoutType = null
     this.statusCode = 0
-    this.statusText = ''
+    this.statusText = EMPTY_BUF
     this.upgrade = false
     this.headers = []
     this.headersSize = 0
@@ -397,7 +463,14 @@ class Parser {
    * @returns {0}
    */
   onStatus (buf) {
-    this.statusText = buf.toString()
+    if (this.statusText === EMPTY_BUF) {
+      this.statusText = buf
+    } else if (Array.isArray(this.statusText)) {
+      this.statusText.push(buf)
+    } else {
+      this.statusText = [this.statusText, buf]
+    }
+
     return 0
   }
 
@@ -503,7 +576,7 @@ class Parser {
     assert(request.upgrade || request.method === 'CONNECT')
 
     this.statusCode = 0
-    this.statusText = ''
+    this.statusText = EMPTY_BUF
     this.shouldKeepAlive = false
 
     this.headers = []
@@ -540,7 +613,7 @@ class Parser {
    * @returns {number}
    */
   onHeadersComplete (statusCode, upgrade, shouldKeepAlive) {
-    const { client, socket, headers, statusText } = this
+    const { client, socket, headers } = this
 
     if (socket.destroyed) {
       return -1
@@ -623,7 +696,7 @@ class Parser {
       socket[kReset] = true
     }
 
-    const pause = request.onResponseStart(statusCode, headers, this.resume, statusText) === false
+    const pause = request.onResponseStart(statusCode, headers, this.resume, parseStatusText(statusCode, this.statusText)) === false
 
     if (request.aborted) {
       return -1
@@ -703,7 +776,7 @@ class Parser {
     assert(request)
 
     this.statusCode = 0
-    this.statusText = ''
+    this.statusText = EMPTY_BUF
     this.bytesRead = 0
     this.contentLength = -1
     this.keepAlive = ''

--- a/test/request.js
+++ b/test/request.js
@@ -2,6 +2,7 @@
 
 const { tspl } = require('@matteo.collina/tspl')
 const { createServer } = require('node:http')
+const { createServer: createNetServer } = require('node:net')
 const { test, after, describe } = require('node:test')
 const { request, errors } = require('..')
 
@@ -559,6 +560,31 @@ test('request should include statusText in response', async t => {
 
   t.strictEqual(statusText, 'Custom Status Text')
   await body.dump()
+  t.ok('request completed')
+})
+
+test('request should include statusText in response when reason phrase is split', async t => {
+  t = tspl(t, { plan: 3 })
+
+  const server = createNetServer((socket) => {
+    socket.write('HTTP/1.1 200 O')
+    socket.write('K\r\ncontent-length: 5\r\n\r\nhello')
+  })
+
+  after(() => {
+    server.close()
+  })
+
+  await new Promise((resolve) => server.listen(0, resolve))
+
+  const { statusText, body } = await request({
+    method: 'GET',
+    origin: `http://localhost:${server.address().port}`,
+    path: '/'
+  })
+
+  t.strictEqual(statusText, 'OK')
+  t.strictEqual(await body.text(), 'hello')
   t.ok('request completed')
 })
 


### PR DESCRIPTION
Posted for reference.

Benchmarks show the change is not worth the complexity in readability

```console
benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• status text common reason phrases
------------------------------------------- -------------------------------
eager decode                 272.46 ns/iter 274.62 ns  █▂                  
                    (261.90 ns … 668.51 ns) 316.49 ns ▃██▃                 
                    (148.25  b … 414.20  b) 217.24  b ██████▆▄▃▂▃▂▂▂▁▂▁▁▁▁▁

deferred map                 263.36 ns/iter 262.21 ns  █▇                  
                    (256.92 ns … 310.36 ns) 294.51 ns ▃██▄                 
                    (  0.09  b … 182.11  b)   0.61  b ████▃▂▁▁▁▁▁▁▁▂▁▃▂▃▂▂▁

• status text custom reason phrases
------------------------------------------- -------------------------------
eager decode                 161.02 ns/iter 160.13 ns ██                   
                    (156.61 ns … 207.60 ns) 191.95 ns ██                   
                    ( 59.94  b … 312.12  b) 176.36  b ███▅▂▂▁▁▂▁▂▂▂▂▁▁▂▂▁▁▁

deferred fallback decode     181.64 ns/iter 183.40 ns ▆█                   
                    (178.48 ns … 235.65 ns) 208.35 ns ██                   
                    ( 26.11  b … 319.14  b) 120.65  b ██▃▂▇▆▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁

• status text split reason phrases
------------------------------------------- -------------------------------
eager decode                 288.23 ns/iter 289.87 ns  ▃█▂                 
                    (279.98 ns … 359.41 ns) 327.16 ns ▅███▃                
                    (106.03  b … 330.11  b) 152.50  b █████▇▅▄▄▂▂▁▂▂▁▂▂▁▂▁▁

deferred map                 107.50 ns/iter 106.90 ns  █                   
                    (105.36 ns … 143.21 ns) 130.74 ns  █                   
                    ( 52.14  b … 414.42  b) 192.27  b ▇█▅▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

• status text mixed responses
------------------------------------------- -------------------------------
eager decode                   1.54 µs/iter   1.54 µs  █                   
                        (1.52 µs … 1.63 µs)   1.61 µs ▅█                   
                    (911.86  b … 913.07  b) 912.21  b ███▃▅▂▂▃▃▄▃▁▂▁▁▁▂▂▂▂▂

deferred map/fallback          1.43 µs/iter   1.43 µs    █                 
                        (1.41 µs … 1.48 µs)   1.46 µs  ▂ ██▇▄▄             
                    (312.06  b … 312.85  b) 312.13  b ████████▄▄▃▃▅▂▁▂▂▄▃▃▂
```